### PR TITLE
docs: reconcile stale PyPI claim in CLAUDE.md + add tier column to AGENTS.md 17-agent table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,25 +37,29 @@ Specify supports multiple AI agents by generating agent-specific command files a
 
 ### Current Supported Agents
 
-| Agent                      | Directory              | Format   | CLI Tool        | Description                 |
-| -------------------------- | ---------------------- | -------- | --------------- | --------------------------- |
-| **Claude Code**            | `.claude/commands/`    | Markdown | `claude`        | Anthropic's Claude Code CLI |
-| **Gemini CLI**             | `.gemini/commands/`    | TOML     | `gemini`        | Google's Gemini CLI         |
-| **GitHub Copilot**         | `.github/agents/`      | Markdown | N/A (IDE-based) | GitHub Copilot in VS Code   |
-| **Cursor**                 | `.cursor/commands/`    | Markdown | `cursor-agent`  | Cursor CLI                  |
-| **Qwen Code**              | `.qwen/commands/`      | TOML     | `qwen`          | Alibaba's Qwen Code CLI     |
-| **opencode**               | `.opencode/command/`   | Markdown | `opencode`      | opencode CLI                |
-| **Codex CLI**              | `.codex/commands/`     | Markdown | `codex`         | Codex CLI                   |
-| **Windsurf**               | `.windsurf/workflows/` | Markdown | N/A (IDE-based) | Windsurf IDE workflows      |
-| **Kilo Code**              | `.kilocode/rules/`     | Markdown | N/A (IDE-based) | Kilo Code IDE               |
-| **Auggie CLI**             | `.augment/rules/`      | Markdown | `auggie`        | Auggie CLI                  |
-| **Roo Code**               | `.roo/rules/`          | Markdown | N/A (IDE-based) | Roo Code IDE                |
-| **CodeBuddy CLI**          | `.codebuddy/commands/` | Markdown | `codebuddy`     | CodeBuddy CLI               |
-| **Qoder CLI**              | `.qoder/commands/`     | Markdown | `qoder`         | Qoder CLI                   |
-| **Amazon Q Developer CLI** | `.amazonq/prompts/`    | Markdown | `q`             | Amazon Q Developer CLI      |
-| **Amp**                    | `.agents/commands/`    | Markdown | `amp`           | Amp CLI                     |
-| **SHAI**                   | `.shai/commands/`      | Markdown | `shai`          | SHAI CLI                    |
-| **IBM Bob**                | `.bob/commands/`       | Markdown | N/A (IDE-based) | IBM Bob IDE                 |
+The CLI accepts **17 agent keys**, but they are **NOT all equally validated**. Per README "AI coding agents supported," `Supported` = wired end-to-end and exercised on every release; `Experimental` = templates install correctly and the agent key is accepted, but agent-specific wiring is not exhaustively tested.
+
+| Agent                      | Tier             | Directory              | Format   | CLI Tool        | Description                 |
+| -------------------------- | ---------------- | ---------------------- | -------- | --------------- | --------------------------- |
+| **Claude Code**            | **Supported**    | `.claude/commands/`    | Markdown | `claude`        | Anthropic's Claude Code CLI |
+| **Gemini CLI**             | **Supported**    | `.gemini/commands/`    | TOML     | `gemini`        | Google's Gemini CLI         |
+| **GitHub Copilot**         | **Supported**    | `.github/agents/`      | Markdown | N/A (IDE-based) | GitHub Copilot in VS Code   |
+| **Cursor**                 | **Supported**    | `.cursor/commands/`    | Markdown | `cursor-agent`  | Cursor CLI                  |
+| **Windsurf**               | **Supported**    | `.windsurf/workflows/` | Markdown | N/A (IDE-based) | Windsurf IDE workflows      |
+| **Qwen Code**              | *Experimental*   | `.qwen/commands/`      | TOML     | `qwen`          | Alibaba's Qwen Code CLI     |
+| **opencode**               | *Experimental*   | `.opencode/command/`   | Markdown | `opencode`      | opencode CLI                |
+| **Codex CLI**              | *Experimental*   | `.codex/commands/`     | Markdown | `codex`         | Codex CLI                   |
+| **Kilo Code**              | *Experimental*   | `.kilocode/rules/`     | Markdown | N/A (IDE-based) | Kilo Code IDE               |
+| **Auggie CLI**             | *Experimental*   | `.augment/rules/`      | Markdown | `auggie`        | Auggie CLI                  |
+| **Roo Code**               | *Experimental*   | `.roo/rules/`          | Markdown | N/A (IDE-based) | Roo Code IDE                |
+| **CodeBuddy CLI**          | *Experimental*   | `.codebuddy/commands/` | Markdown | `codebuddy`     | CodeBuddy CLI               |
+| **Qoder CLI**              | *Experimental*   | `.qoder/commands/`     | Markdown | `qoder`         | Qoder CLI                   |
+| **Amazon Q Developer CLI** | *Experimental*   | `.amazonq/prompts/`    | Markdown | `q`             | Amazon Q Developer CLI      |
+| **Amp**                    | *Experimental*   | `.agents/commands/`    | Markdown | `amp`           | Amp CLI                     |
+| **SHAI**                   | *Experimental*   | `.shai/commands/`      | Markdown | `shai`          | SHAI CLI                    |
+| **IBM Bob**                | *Experimental*   | `.bob/commands/`       | Markdown | N/A (IDE-based) | IBM Bob IDE                 |
+
+Experimental-tier issues are labeled `experimental` and triaged best-effort. PRs that promote an agent to Supported tier are welcome — see `SUPPORT.md` for triage policy and promotion criteria.
 
 ### Step-by-Step Integration Guide
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Key architectural components that span multiple files:
 - **`.specify/subagents/`** — 21+ base subagents plus 146 mobile-specific ones organized by lifecycle phase (01-Discovery through 14-Documentation). Matched dynamically by **semantic similarity** between feature keywords and YAML frontmatter `description`, NOT hard-coded.
 - **`specs/_defaults/registry.yaml`** — the Project Defaults Registry. 80+ technical decisions (architecture pattern, data access style, tenancy model, etc.). Every command reads this on entry and offers to update it on exit (with HITL approval).
 - **`memory/constitution.md`** — Article IX hardcodes the 9 Prime Directives (Directive 9 added in v0.3 for the Orientation Read Surface). Articles I-VIII are `[PLACEHOLDER]` sections filled in by `/atomicspec.constitution` in consumer projects.
-- **`src/specify_cli/__init__.py`** — the `atomicspec` Python CLI (PyPI distribution name: `atomic-spec`). Thin wrapper that downloads template releases and sets up agent-specific command directories. **Note:** the CLI's `repo_owner`/`repo_name` still point at upstream `github/spec-kit` for release zips — that path is orthogonal to the `init-project.sh` installer this repo documents. The v0.1.0 release will either repoint the CLI or publish release zips here; until then, `init-project.sh` is the canonical install path.
+- **`src/specify_cli/__init__.py`** — the `atomicspec` Python CLI (PyPI distribution name: `atomic-spec`). Thin wrapper that downloads template releases and sets up agent-specific command directories. The CLI fetches templates from `Chappygo-OS/Atomic-Spec` GitHub Releases (overridable via `ATOMIC_SPEC_REPO` and `ATOMIC_SPEC_ASSET_PREFIX` env vars). **PyPI distribution is live since v0.2.0** (Trusted Publishing via OIDC, `pypi` environment-gated). `init-project.{sh,ps1}` remains a valid alternative install path for offline/local setups using this repo's templates directly.
 
 ## Critical Conventions
 
@@ -72,17 +72,19 @@ This repo doesn't build or test in the traditional sense — it's a framework di
 
 Supported agents: `claude`, `gemini`, `copilot`, `cursor`, `windsurf`. The init scripts currently support only these five — the Python CLI supports ~18 more.
 
-**Python CLI (for distribution via PyPI):**
+**Python CLI (distributed via PyPI since v0.2.0):**
 ```bash
-# Install
-# Planned for v0.1.0 release
+# Install (live on PyPI)
 uv tool install atomic-spec
+# or: pipx install atomic-spec
 
 # Initialize
-specify init <project-name> --ai claude
-specify init . --here --ai claude
-specify check  # verify installed tools
+atomicspec init <project-name> --ai claude
+atomicspec init . --here --ai claude
+atomicspec check  # verify installed tools
 ```
+
+Note: the legacy alias `specify` is still mentioned in some upstream docs; the canonical command name in Atomic Spec is `atomicspec`.
 
 **Scripts invoked by command templates** (not called directly by humans):
 - `scripts/bash/check-prerequisites.sh` — validates gates before phase transitions


### PR DESCRIPTION
## Summary

Two doc inconsistencies surfaced after v0.3.0 ship:

1. **`CLAUDE.md` said the PyPI install was "Planned for v0.1.0 release"** — stale since v0.2.0. README already shows the install as live; CLAUDE.md was never refreshed. Anyone using CLAUDE.md as the source of truth would have tried pip and hit a wall thinking the package wasn't published.

2. **`AGENTS.md` "Current Supported Agents" table listed all 17 agents uniformly** with no Supported/Experimental column. The README correctly splits them 5 vs 12 (lines 183–185), so a reader using AGENTS.md alone would have concluded all 17 are equally validated — contradicting the README.

## Changes

- `CLAUDE.md`: two PyPI-related stale sentences replaced with current state (PyPI live since v0.2.0; Trusted Publishing via OIDC; `init-project.{sh,ps1}` remains a valid alternative).
- `AGENTS.md`: added `Tier` column to the 17-agent table (5 Supported / 12 Experimental, matching README), plus a disclosure sentence above the table and a SUPPORT.md cross-ref below it.

## Test plan

- [ ] Visual diff of CLAUDE.md — confirm no remaining "Planned" / "until then" / "v0.1.0 release" language for the CLI
- [ ] Visual diff of AGENTS.md — table now has 6 columns; first 5 rows tagged Supported, next 12 Experimental
- [ ] Cross-check README lines 183–185 — tier split matches exactly