### PR TITLE
v0.4.0 — advisory model-tier routing + efficiency CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,50 @@ All notable changes to the Specify CLI and templates are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-08-21
+
+> **v0.4 theme**: introduce advisory model-tier routing so consumer projects can split coordinator-role turns (Phase 0 orientation, gate checks, stamp writes) from implementer-role turns (code generation, verification loop) and HITL turns (Directive 6 checkpoints) onto different model tiers — Haiku / Sonnet / Opus by default on Anthropic, arbitrary strings for other providers. Shipped **advisor-off by default**: consumer projects on v0.3 see byte-for-byte identical behavior after upgrade. Per-feature measurement primitive lands in v0.4.1; v0.4 ships the config surface + lightweight advisory reporting so the tier map is exercisable and the promotion evidence bar is buildable. Follows the v0.3.0 → v0.3.1 "surface first, enforcement second" pattern that already held up.
+
+### Added
+
+- **Registry `efficiency:` block (v0.4+)** — new top-level in `templates/registry-template.yaml`. Fields: `model_tiers.coordinator` (default `claude-haiku-4-5`), `model_tiers.implementer` (default `claude-sonnet-4-6`), `model_tiers.hitl` (default `claude-opus-4-7`), `advisor_enabled` (default `false`), `snapshot_recorded` (default `null`). Registry schema bump **5 → 6**. Governed by Directive 7 — every field is amended via the standard `/atomicspec.registry` HITL flow.
+- **`atomicspec select-model --phase <coordinator|implementer|hitl>`** — machine-readable CLI subcommand for command templates. Prints the configured model on stdout, or empty on `advisor_enabled: false` / missing block / unset tier. Exit code always 0 so bash/PowerShell callers can `MODEL=$(atomicspec select-model ...)` and branch on `[ -n "$MODEL" ]` cleanly.
+- **`atomicspec cost snapshot`** — single-number cost snapshot recorder. Writes `.specify/efficiency-snapshots/<date>-<scope>.md` with YAML frontmatter (amount, provider, source, feature, tokens, note). Any provider. Atomic-write pattern (`.tmp` → rename). Advisory only — not per-turn measurement.
+- **`atomicspec efficiency report --advisory`** — prints tier resolution table + recent snapshots. Header labeled "advisory only" verbatim so it never reads as authoritative billing evidence. Silent no-op when no snapshots exist.
+- **Phase 1 Prelude — Efficiency Hint** — advisory prose block added to `templates/commands/specify.md`, `plan.md`, `tasks.md`, and `implement.md` at their Phase 0 anchors. Invokes `atomicspec select-model` and records the resolved model in orientation evidence. Does not affect gate criteria, Directive 3 pinning, or downstream steps. Advisory-only surface; naming is deliberately "Phase 1 Prelude," never "Phase 0.5."
+- **`## Efficiency` H2 block** — added to `implement.md` §0.6's per-run orientation-evidence template. Every Phase 0 run now records `advisor_enabled`, tier map source, and resolved models per phase. `atomicspec efficiency report --advisory` reads these files.
+- **`src/specify_cli/_registry.py`** (new module) — `load_registry()` + `resolve_tier()` helpers using `yaml.safe_load` exclusively. Graceful degradation: missing file, missing block, malformed YAML never raise. `TierResolution` dataclass returns a `reason` diagnostic (`resolved` / `advisor-disabled` / `efficiency-block-missing` / `tier-unset` / ...) for report rendering.
+- **`pyyaml>=6.0,<7`** — first YAML lib in the Python CLI. `safe_load`-only by design; every 2024–2026 PyYAML CVE is a `yaml.load()` deserialization attack, and `safe_load` is immune. Matches the upstream `github/spec-kit` dep set, and every peer template-distributor Python CLI (cookiecutter, copier, ansible).
+- **`docs/efficiency.md`** (new) — user-facing efficiency doc: how to configure the tier map, how to read the `--advisory` report, provider-portability posture, roadmap to v0.4.1 hook-based measurement, naming disambiguation vs the per-subagent `model:` frontmatter in `.specify/subagents/**/*.md`.
+
+### Changed
+
+- **Directive 7 (Project Defaults Registry) — clause amendment**: the enumerated scope list gains one bullet, *"Efficiency model-tier mapping (v0.4+) — coordinator/implementer/HITL model assignments used advisorily by `/atomicspec.implement` and its siblings for tier routing."* Nine directives stays nine — clause amendment, not new directive. Follows the v0.2 in-place precedent (commit `0185b86`).
+- **Directive 8 (Self-Contained Tasks) — companion row** added to the Embedded Context table: *"Efficiency Tier Hint (v0.4+) — Derived at read time from `registry.efficiency.model_tiers` + task phase. Optional; defaults to `implementer` when unset."* Row added; no other rows changed.
+- **Constitution mirror** — `site/src/content/docs/prime-directives.mdx` updated in lockstep with `memory/constitution.md`. Same commit, same wording.
+
+### Honest disclosures (v0.4.0)
+
+- **Advisor is OFF by default** (`advisor_enabled: false`). Consumer projects upgrading from v0.3 see byte-for-byte identical behavior until they explicitly flip it. The 28% cost-reduction figure the tier map is designed around is a **projection from Anthropic's own SWE-bench Multilingual eval (April 2026, −11.9% cost + 2.7 pp quality)**, extrapolated to Atomic Spec's coordination-heavy workload. It is not a v0.4-measured savings claim. Per-feature measurement lands in v0.4.1.
+- **Per-feature `baseline record` deliberately deferred to v0.4.1.** The command as originally scoped in the v0.4 PRD would have shipped either a client-side estimate (which Anthropic's own docs explicitly warn is not authoritative billing data) or a JSONL log tailer with documented P0 failure modes (30-day retention wipes, auto-update deletion, undocumented schema, Windows path collisions, ~2.3× duplicate-token inflation). v0.4.1 rebuilds it on Claude Code's stable hook API (`Stop` / `PostToolUse` / `SessionEnd`) plus Anthropic Console CSV import for API-key users, then flips `advisor_enabled` default to `true` behind the promotion evidence bar.
+- **Provider coverage is deliberately incomplete.** Claude Code / Codex CLI / Anthropic-API-key users all have measurement paths (Claude Code hooks in v0.4.1; Codex JSONL adapter later; CSV import for API users in v0.4.1). Cursor / Windsurf / Copilot / Gemini CLI have no equivalent hook API and no path to token-level measurement in v0.4.x. The tier config still applies to them advisorily; they just don't measure. This is honest about a real constraint, not a workaround.
+- **`select-model` is advisory, not enforcing.** Agents that respect per-turn model selection (Claude Code subagent `Task` tool) may honor the hint; other agents record it in orientation evidence and continue on their default model. This is by design — Atomic Spec is a governance framework, not a request-path proxy.
+- **`select-model.sh` / `select-model.ps1` were considered and rejected.** Python CLI is the single source of truth for reading `registry.efficiency`. Bash/PowerShell command-template blocks invoke `atomicspec select-model` directly. Avoids awk-parser drift and doubled maintenance for zero capability gain.
+
+### Migration notes
+
+**Fully backwards compatible.** Consumer projects on v0.3 upgrade to v0.4 with **no behavior change** unless they explicitly opt in:
+
+1. Existing `registry.yaml` files with `version: 5` continue to work. The `check-prerequisites.sh` awk classifier ignores the new top-level `efficiency:` block (structural-key skip-list is unchanged).
+2. Fresh `atomicspec init` writes `version: 6` with `advisor_enabled: false`. First `/atomicspec.plan` run auto-backfills `_provenance: efficiency.*` entries as `unknown_legacy` (template defaults were not human-chosen).
+3. Command templates gain the "Phase 1 Prelude — Efficiency Hint" block. When `advisor_enabled: false`, `atomicspec select-model` returns empty and templates proceed with byte-for-byte v0.3 behavior.
+4. Orientation-run files gain the `## Efficiency` H2 section. When advisor is off, the section reports `advisor_enabled: false` and the tier fields as `n/a`. Existing `orientation-runs/` files are not rewritten.
+
+Consumers wanting to try the advisor:
+1. Edit `specs/_defaults/registry.yaml`: set `efficiency.advisor_enabled: true`.
+2. (Optional) Replace `model_tiers.*` with provider-native model IDs for OpenAI / Google / etc.
+3. Run any `/atomicspec.*` command — resolved tier now appears in orientation evidence.
+
 ## [0.3.0] - 2026-06-21
 
 > **v0.3 theme**: close the cross-provider AI handoff gap. When Claude crashes mid-feature and the user switches to Codex (or hits a quota cliff and falls over to Gemini), the receiving AI now self-orients from files alone — detects which artifacts are half-done, prompts the user on conflict, and resumes cleanly without silently overwriting work. A new sibling Directive (9) governs this read surface narrowly so Directive 3's Context Pinning stays verbatim.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/atomic-spec.svg?logo=python&logoColor=white)](https://pypi.org/project/atomic-spec/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Agents supported](https://img.shields.io/badge/agents-17-8A2BE2)](#ai-coding-agents-supported)
-[![Status](https://img.shields.io/badge/status-v0.3.x%20%E2%80%94%20APIs%20may%20change-yellow)](#status)
+[![Status](https://img.shields.io/badge/status-v0.4.x%20%E2%80%94%20APIs%20may%20change-yellow)](#status)
 
 **Spec-kit taught AI agents a workflow. Atomic Spec makes them obey it.** When `/atomicspec.implement` runs, the agent is *architecturally prevented* from reading `plan.md` or `spec.md` — it sees only the current task file, pre-loaded with every registry value, domain rule, and gate criterion it needs. No drifting mid-feature. No hallucinating a new approach on pass three. No 800-line "kitchen sink" PRs.
 
@@ -19,17 +19,17 @@ atomicspec init my-project --ai claude
 
 </div>
 
-> **TL;DR** — One AI instruction file isn't enough. Atomic Spec enforces **eight non-negotiable rules**: one task per file, AI sees only the current task during coding, human sign-off at four checkpoints, and a project registry that remembers every decision. If you've ever reviewed an AI PR and thought *"where did this pattern come from?"* — that's the problem this exists to kill.
+> **TL;DR** — One AI instruction file isn't enough. Atomic Spec enforces **nine non-negotiable rules**: one task per file, AI sees only the current task during coding, human sign-off at four checkpoints, a project registry that remembers every decision, and cross-provider handoff detection so a fresh session picks up exactly where the last one crashed. If you've ever reviewed an AI PR and thought *"where did this pattern come from?"* — that's the problem this exists to kill.
 
 ---
 
 ## Status
 
-**v0.3.0 · current.** The core governance model (now Nine Prime Directives — Directive 9 added in v0.3 for the Orientation Read Surface) is stable and exercised on every release. APIs and command names may evolve through v0.x. Claude Code is the reference implementation and validated end-to-end; 12 other agents are experimental (templates install correctly, agent-specific wiring not yet exhaustively tested). [See the agent tier table below](#ai-coding-agents-supported).
+**v0.4.0 · current.** The core governance model (Nine Prime Directives — Directive 9 added in v0.3 for the Orientation Read Surface) is stable and exercised on every release. APIs and command names may evolve through v0.x. Claude Code is the reference implementation and validated end-to-end; 12 other agents are experimental (templates install correctly, agent-specific wiring not yet exhaustively tested). [See the agent tier table below](#ai-coding-agents-supported).
 
-**New in v0.3 — cross-provider AI handoff.** *Enforcement scope*: Lifecycle Markers, stamp-lifecycle scripts, and cross-phase pre-flight guards (in `/clarify`, `/plan`, `/tasks`) are machine-enforced. The Phase 0 Orientation procedure and Directive 9's `orientation-runs/` evidence requirement are **policy-enforced in v0.3.0** (the AI's compliance with Article IX is the control); the runtime gate (`check-prerequisites --check-orientation`) that BLOCKS Phase 1 on missing evidence ships in v0.3.1. Non-Claude `init-project` paths (gemini / copilot / cursor / windsurf + 12 experimental) ship via the PyPI CLI build pipeline in the same release window; until then, `--ai claude` is the only bash/PowerShell init path with full `{{AGENT_NAME}}` substitution.
+**New in v0.4 — advisory model-tier routing.** Consumer projects can now split coordinator turns (Phase 0 orientation, task selection, gate checks, stamp writes) from implementer turns (code generation, verification loop) and HITL turns (Directive 6 checkpoints) onto different model tiers. Defaults on Anthropic: Haiku for coordination, Sonnet for implementation, Opus for HITL. Shipped **advisor-off by default** (`registry.efficiency.advisor_enabled: false`) — consumer projects on v0.3 see byte-for-byte identical behavior after upgrade. Two new CLI subcommands surface the config: `atomicspec select-model --phase <coordinator|implementer|hitl>` (machine-readable model lookup) and `atomicspec efficiency report --advisory` (dry-run of tier decisions + snapshot log). Per-feature measurement primitive lands in v0.4.1 on Claude Code's stable hook API + Anthropic Console CSV import; v0.4 ships the config surface + honest snapshot recorder (`atomicspec cost snapshot`), not per-turn accounting. Directives 7 and 8 amended in place — nine directives stays nine. Full details: [`docs/efficiency.md`](./docs/efficiency.md).
 
- When Claude crashes mid-feature and you switch to Codex (or Gemini, Cursor, etc.), the receiving AI now self-orients from files alone: detects which artifacts are half-done via Lifecycle Markers stamps, prompts you on conflict, and resumes cleanly without silently overwriting work. The orientation block is auto-injected into every agent file (CLAUDE.md / GEMINI.md / AGENTS.md / .cursorrules / 12 others), so a fresh provider session learns the framework rules on first read. See the v0.3 entry in [CHANGELOG.md](./CHANGELOG.md) for the full mechanism and honest disclosures.
+**New in v0.3 — cross-provider AI handoff.** Lifecycle Markers, stamp-lifecycle scripts, and cross-phase pre-flight guards (in `/clarify`, `/plan`, `/tasks`) are machine-enforced. The Phase 0 Orientation procedure and Directive 9's `orientation-runs/` evidence requirement are **policy-enforced in v0.3.0** (the AI's compliance with Article IX is the control); the runtime gate (`check-prerequisites --check-orientation`) that BLOCKS Phase 1 on missing evidence ships in v0.3.1. When Claude crashes mid-feature and you switch to Codex (or Gemini, Cursor, etc.), the receiving AI now self-orients from files alone: detects which artifacts are half-done via Lifecycle Markers stamps, prompts you on conflict, and resumes cleanly without silently overwriting work. See the v0.3 entry in [CHANGELOG.md](./CHANGELOG.md) for the full mechanism and honest disclosures.
 
 ---
 
@@ -612,6 +612,16 @@ Tasks follow a numbering scheme by phase:
 | `/atomicspec.analyze` | Cross-artifact consistency analysis |
 | `/atomicspec.checklist` | Generate quality validation checklists |
 | `/atomicspec.taskstoissues` | Convert tasks to GitHub issues |
+
+### Efficiency Commands (v0.4+)
+
+Advisory tier routing and cost snapshotting. All commands work with `advisor_enabled: false` (v0.4 default); they simply return empty or unchanged output. Full details: [`docs/efficiency.md`](./docs/efficiency.md).
+
+| Command | Description |
+|---------|-------------|
+| `atomicspec select-model --phase <coordinator\|implementer\|hitl>` | Machine-readable model lookup for command templates. Prints the configured tier model or empty on advisor-off. |
+| `atomicspec cost snapshot --amount <USD> --provider <name> [--feature NNN] [--tokens N] [--note "..."]` | Record a single-number cost snapshot from paste / CSV / JSONL. Writes `.specify/efficiency-snapshots/`. |
+| `atomicspec efficiency report --advisory [--feature NNN] [--limit N]` | Print the tier resolution table + recent snapshots. `--advisory` required; per-feature measurement lands in v0.4.1. |
 
 ### Cleanup Command Details
 

--- a/docs/efficiency.md
+++ b/docs/efficiency.md
@@ -1,0 +1,239 @@
+# Efficiency — advisory model-tier routing (v0.4+)
+
+Atomic Spec v0.4 introduces **advisory** model-tier routing: consumer projects
+can pin a coordinator model for coordination-heavy turns, an implementer model
+for actual code generation, and a HITL model for human-in-the-loop checkpoints.
+This is the config surface. Per-feature token measurement lands in v0.4.1.
+
+> **Advisor is OFF by default.** A fresh `atomicspec init` writes
+> `registry.efficiency.advisor_enabled: false`. Consumer projects on v0.3 see
+> byte-for-byte identical behavior after upgrade until they explicitly flip it.
+
+---
+
+## The three tiers
+
+| Phase | Default model | Typical turns |
+|-------|---------------|---------------|
+| `coordinator` | `claude-haiku-4-5` | Phase 0 orientation, task selection from `index.md`, gate criteria evaluation, stamp-lifecycle writes, traceability updates |
+| `implementer` | `claude-sonnet-4-6` | Task-body work, code generation, verification loop |
+| `hitl` | `claude-opus-4-7` | Directive 6 checkpoints (Phase 0.5 / 0.7 / 0.8 / 0.9 in `/atomicspec.plan`), ambiguous decisions, adversarial review passes |
+
+The tier names are stable across providers. The **values** are provider-native
+model IDs — you replace them via `/atomicspec.registry` for OpenAI, Google, or
+any other provider. Cursor, Windsurf, Copilot, and Gemini CLI have no per-turn
+model selection API, so the tier map applies advisorily to them without
+mid-run switching.
+
+---
+
+## Where the config lives
+
+```yaml
+# specs/_defaults/registry.yaml
+efficiency:
+  model_tiers:
+    coordinator: claude-haiku-4-5
+    implementer: claude-sonnet-4-6
+    hitl:        claude-opus-4-7
+  advisor_enabled: false     # v0.4 default; v0.4.1 flips to true
+  snapshot_recorded: null    # ISO-8601 of last `atomicspec cost snapshot`
+```
+
+Amend via `/atomicspec.registry` — the normal Directive 7 HITL protocol
+applies. Direct edits work too, but the AI is required to raise
+`AskUserQuestion` before committing to any structural change.
+
+---
+
+## Enabling the advisor
+
+1. Open `specs/_defaults/registry.yaml`, find the `efficiency:` block.
+2. Set `advisor_enabled: true`.
+3. (Optional) Replace `model_tiers.*` with provider-native IDs if you're not
+   on Anthropic.
+4. Run any `/atomicspec.*` command. The resolved tier now appears in
+   orientation evidence.
+
+---
+
+## What `select-model` does
+
+```bash
+$ atomicspec select-model --phase coordinator
+claude-haiku-4-5
+$ atomicspec select-model --phase implementer
+claude-sonnet-4-6
+```
+
+When `advisor_enabled: false`, both print empty:
+
+```bash
+$ atomicspec select-model --phase coordinator
+$
+```
+
+Command templates call it from bash / PowerShell blocks and record the
+result in orientation evidence. Agents that support per-turn model selection
+(Claude Code's subagent `Task` tool) MAY honor the hint; others record it and
+continue on their default model.
+
+Exit code is always 0 — bash / PowerShell callers branch on `[ -n "$MODEL" ]`
+rather than exit code, keeping the empty-model path trivial.
+
+---
+
+## What `cost snapshot` does
+
+```bash
+$ atomicspec cost snapshot \
+    --amount 1.50 \
+    --provider anthropic \
+    --source paste \
+    --feature 042 \
+    --tokens 45000 \
+    --note "manual paste from Anthropic Console"
+```
+
+Writes `.specify/efficiency-snapshots/2026-08-21-034512123456-feature-042.md`
+with YAML frontmatter (numeric fields) + prose summary. Atomic-write pattern
+(`.tmp` → rename). Advisory only: not per-turn measurement, not billing-grade.
+
+**Snapshot file naming and retention**:
+
+- Filename format: `YYYY-MM-DD-HHMMSSuuuuuu-<scope>.md` (UTC date + time +
+  microseconds + scope). The microsecond suffix is what prevents two
+  same-second calls (e.g., a shell loop importing multiple lines) from
+  overwriting each other.
+- Scope is `feature-<id>` when `--feature` is passed, `adhoc` otherwise.
+- Every `atomicspec cost snapshot` invocation writes one new file. **The
+  framework never deletes snapshots.** If you want retention, roll them
+  off yourself (e.g., delete files older than N days). A future
+  `atomicspec efficiency prune` command may formalize this once v0.4.1
+  measurement lands and snapshot volume becomes a real concern.
+- The report reads snapshots by parsing YAML frontmatter, then sorting by
+  the `recorded_at` field. Ordering is precise even when many snapshots
+  share the same date.
+
+**Why manual paste in v0.4?** Because every automated approach we evaluated
+had P0 failure modes we weren't willing to ship. See the honest disclosures in
+`CHANGELOG.md` v0.4.0. v0.4.1 lands hook-based auto-capture for Claude Code and
+CSV import for Anthropic API-key users, at which point manual paste becomes a
+fallback rather than the default.
+
+**Two directories, not one**:
+
+- `.specify/efficiency-snapshots/` (v0.4) — human-entered single-number
+  cost snapshots via `atomicspec cost snapshot`. Advisory. Any provider.
+- `.specify/efficiency-baselines/` (v0.4.1) — hook-captured per-feature
+  token/cost baselines from `atomicspec baseline record`. Claude Code
+  today; Codex CLI and Anthropic Console CSV import shortly after. Not
+  present until v0.4.1.
+
+The two are separate on purpose: snapshots are for calibration and manual
+reconciliation; baselines are the falsifiability evidence that gates the
+advisor-default flip.
+
+---
+
+## What `efficiency report --advisory` does
+
+```bash
+$ atomicspec efficiency report --advisory
+```
+
+Prints:
+
+1. A tier resolution table (`Phase | Advisor | Configured model | Reason`) with
+   a header labeled "advisory only, measurement in v0.4.1" verbatim.
+2. Recent cost snapshots table if any exist in `.specify/efficiency-snapshots/`.
+
+The `--advisory` flag is required in v0.4. Running without it prints a note
+and exits 1. This is deliberate: the flag is a machine-readable marker that
+you understand the output is not authoritative billing evidence.
+
+`--feature NNN` filters the snapshot listing. `--limit N` caps the row count
+(default 5).
+
+---
+
+## Provider-portability posture
+
+| Provider | Coordinator | Implementer | HITL | Measurement path (v0.4.1) |
+|----------|-------------|-------------|------|---------------------------|
+| Anthropic (Claude Code) | Haiku 4.5 | Sonnet 4.6 | Opus 4.7 | Claude Code hook API |
+| Anthropic via API key | Haiku 4.5 | Sonnet 4.6 | Opus 4.7 | Anthropic Console CSV import |
+| Anthropic via Bedrock | Same model IDs | Same | Same | CSV via Bedrock billing export |
+| OpenAI / Codex CLI | `gpt-5-mini` | `gpt-5` | `gpt-5` high-reasoning | Codex CLI JSONL adapter (v0.4.1) |
+| Google Gemini / Antigravity | Flash | Pro | Pro (thinking-high) | No path in v0.4.x |
+| Cursor / Windsurf / Copilot | Same one model | Same | Same | No path in v0.4.x |
+| Single-model (Ollama, vLLM) | Same one model | Same | Same | Not applicable |
+| Aggregators (OpenRouter, Portkey, LiteLLM, AgentRouter) | Provider-manifest keying in v0.5 | — | — | v0.5+ |
+
+Consumers on providers without a measurement path see the tier config work as
+advisory prose in orientation evidence. Nothing silently claims savings for
+them.
+
+---
+
+## Naming discipline
+
+The v0.4 orientation-adjacent surface is called **"Phase 1 Prelude — Efficiency
+Hint,"** never *"Phase 0.5."* Positioning as a prelude to Phase 1 (rather than
+a sibling to Phase 0) keeps the advisory-only posture consistent with the name
+and avoids borrowing Directive 9's blocking authority. Directive 9 remains a
+strictly narrower Orientation Read Surface; the prelude is advisory.
+
+`registry.efficiency.model_tiers` is the **phase-tier** concept — which model
+runs which kind of turn. It is semantically distinct from the per-subagent
+`model:` frontmatter hint in `.specify/subagents/**/*.md`, which pins a model
+for one named subagent regardless of phase. Don't collapse the two.
+
+---
+
+## Roadmap
+
+- **v0.4.0 (current)**: config surface + advisory reporting.
+- **v0.4.1**: `atomicspec baseline record --feature NNN` via Claude Code
+  hook API (`Stop` / `PostToolUse` / `SessionEnd`) + Anthropic Console CSV
+  importer + Codex CLI JSONL adapter (separate flag). Evidence bar for
+  advisor default flip: ≥60% of tracked consumer projects show non-empty
+  `.specify/efficiency-baselines/` across ≥2 providers; measured cost
+  reduction ≥15% median across baselined features; zero P0 governance
+  regressions for 4 weeks. Advisor default flips to `true` behind this
+  bar.
+- **v0.5**: only if v0.4.1 evidence justifies additional complexity —
+  per-turn hint grammar in command templates, provider adapter layer with
+  contract tests, aggregator-transport manifest keying.
+- **Sunset clause**: if the v0.4 → v0.4.1 evidence bar is unmet by the
+  v0.5 cut date, the efficiency layer freezes at v0.4, `advisor_enabled`
+  is marked `@deprecated` in Article IX, and removal is scheduled for
+  v0.7. Discipline before ambition.
+
+---
+
+## Frequently asked
+
+**"Why is measurement so hard?"**
+Atomic Spec is a template distributor — its CLI is not in the LLM request
+path. Every observability platform (Helicone, Langfuse, LangSmith, Portkey)
+either proxies the request or hooks the SDK; a template distributor cannot
+do either. The two viable paths are (a) provider hook APIs (Claude Code
+exposes these; other agents don't) and (b) provider Admin API / CSV
+exports (Anthropic Console, OpenAI Usage — API-key users only). Both land
+in v0.4.1.
+
+**"Can I just have the agent write its own token counts into an evidence file?"**
+No. Anthropic's own docs explicitly warn that `total_cost_usd` and related
+client-side estimates *"are not authoritative billing data. Do not bill end
+users or trigger financial decisions from these fields."* Cache-read
+tokens are invisible to a model that didn't create the cache. This was
+evaluated and rejected as an anti-pattern.
+
+**"What if I run Claude Code and want cost tracking today?"**
+Use [`ccusage`](https://github.com/ryoppippi/ccusage) — it tails
+`~/.claude/projects/**/*.jsonl` and produces cost reports. Atomic Spec
+v0.4.1 will build the same capability on Claude Code's blessed hook API
+(more stable than JSONL tailing) plus feature-scoping metadata. Until
+then, `atomicspec cost snapshot --source jsonl --amount <ccusage_total>`
+brings a ccusage-derived number into Atomic Spec's snapshot log.

--- a/memory/constitution.md
+++ b/memory/constitution.md
@@ -4,7 +4,7 @@
 
 > **Note to Atomic Spec users**: Articles I–VIII below are **intentionally left as `[PLACEHOLDER]` tokens**. They are filled in per consumer project by running `/atomicspec.constitution` — that command interactively authors your project's governing principles and replaces every placeholder.
 >
-> **Article IX (Prime Directives) is NOT a placeholder** — it is hardcoded below and encodes the eight non-negotiable rules of the Atomic Traceability Model. Do not edit Article IX unless you are deliberately changing framework governance.
+> **Article IX (Prime Directives) is NOT a placeholder** — it is hardcoded below and encodes the nine non-negotiable rules of the Atomic Traceability Model (Directive 9 added in v0.3 for the Orientation Read Surface). Do not edit Article IX unless you are deliberately changing framework governance.
 
 ## Core Principles
 
@@ -195,6 +195,7 @@ Registry-eligible decisions include not only the fields explicitly enumerated in
 - CI/CD platform and deployment workflow
 - Package manager and runtime version pins
 - Testing framework (unit / integration / E2E)
+- **Efficiency model-tier mapping** (v0.4+) — coordinator/implementer/HITL model assignments used advisorily by `/atomicspec.implement` and its siblings for tier routing. See the `registry.efficiency` block. Purely advisory in v0.4 (`advisor_enabled: false` by default); measurement primitive and default flip land in v0.4.1.
 
 **Definition of "commit"**: writing config or code that encodes the choice (e.g., creating `docker-compose.yml`, adding a dependency to `package.json`, importing a framework module), OR recording the choice in `plan.md` or a task file as a fixed value. Drafting a comment that *discusses* options is not committing.
 
@@ -279,6 +280,7 @@ Every task file MUST include an "Embedded Context" section containing:
 | **Feature Summary** | `plan.md` (extracted during task generation) | Always |
 | **Gate Criteria** | Subagent/Station gate checklists | When domain knowledge exists |
 | **Structural Decision Triggers** (v0.2+) | Directive 7 scope list | When the task may commit to containerization, deployment, framework, infrastructure provider, or domain primitive — so the implementer recognizes the AskUserQuestion trigger under Context Pinning |
+| **Efficiency Tier Hint** (v0.4+) | Derived at read time from `registry.efficiency.model_tiers` + task phase | Optional; defaults to `implementer` when unset. Advisory only — surfaces which tier the coordinator/implementer/HITL split would apply for this task's phase, without changing task selection or gate logic |
 
 **Graceful Degradation**:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "atomic-spec"
-version = "0.3.0"
+version = "0.4.0"
 description = "Atomic Traceability for AI-Driven Development — a governance framework that constrains AI coding agents via gated, atomic, context-pinned phases."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -53,6 +53,13 @@ dependencies = [
     "platformdirs",
     "readchar",
     "truststore>=0.10.4",
+    # v0.4+ — read specs/_defaults/registry.yaml to resolve efficiency.model_tiers.
+    # Use yaml.safe_load ONLY (never yaml.load); every 2024–2026 PyYAML CVE is a
+    # yaml.load() deserialization attack. If ruff is present in a dev env, S506
+    # enforces this at lint time; without ruff it is a code-review responsibility.
+    # <7 pin is defensive against a hypothetical breaking major (no signal that
+    # PyYAML 7 is imminent as of this pin).
+    "pyyaml>=6.0,<7",
 ]
 
 [project.urls]
@@ -68,6 +75,14 @@ atomicspec = "specify_cli:main"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+# v0.4+ — enforce the "yaml.safe_load only, never yaml.load" rule at lint time
+# when ruff is available in a dev environment. S506 (suspicious-yaml-load) is
+# ruff's implementation of the same bandit check. Ruff is NOT a runtime dep;
+# this section only matters if a contributor runs `ruff check`. Without ruff
+# installed the rule is a code-review responsibility.
+[tool.ruff.lint]
+extend-select = ["S506"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/specify_cli"]

--- a/site/src/content/docs/atomic-traceability-model.mdx
+++ b/site/src/content/docs/atomic-traceability-model.mdx
@@ -1,6 +1,6 @@
 ---
 title: The Atomic Traceability Model
-description: The governance philosophy that turns Spec-Driven Development into something AI agents cannot quietly subvert — Eight Prime Directives, Knowledge Stations, and Context Pinning, explained.
+description: The governance philosophy that turns Spec-Driven Development into something AI agents cannot quietly subvert — Nine Prime Directives, Knowledge Stations, and Context Pinning, explained.
 category: Concepts
 order: 10
 lastUpdated: 2026-04-29
@@ -12,7 +12,7 @@ lastUpdated: 2026-04-29
 
 Spec-Driven Development (SDD, described below) is the **philosophy**: specifications become executable, generating working implementations rather than guiding them. Atomic Spec is the **governance** that makes SDD survive contact with AI coding agents.
 
-AI agents, left unconstrained, produce drift. They skip gates, invent file structures, read more context than needed, and quietly deviate from decisions made minutes earlier. The Atomic Traceability Model addresses this through **Eight Prime Directives** (see [Article IX of the constitution](/Atomic-Spec/docs/prime-directives)):
+AI agents, left unconstrained, produce drift. They skip gates, invent file structures, read more context than needed, and quietly deviate from decisions made minutes earlier. The Atomic Traceability Model addresses this through **Nine Prime Directives** (see [Article IX of the constitution](/Atomic-Spec/docs/prime-directives)):
 
 1. **Directory Supremacy** — every feature has `index.md` + `traceability.md`
 2. **Atomic Injunction** — `/atomicspec.tasks` produces a `tasks/` directory of individual `T-XXX-[name].md` files; a single `tasks.md` is FORBIDDEN
@@ -311,7 +311,7 @@ At the heart of Atomic Spec lies a constitution — a set of principles that gov
 Atomic Spec's constitution has **ten articles**:
 
 - **Articles I–VIII** are **project-authored placeholders**. Every project instantiates them via `/atomicspec.constitution`, filling in principles appropriate to its domain (library-first design, CLI mandates, TDD, observability, versioning, simplicity, anti-abstraction, or anything else the team chooses to enshrine).
-- **Article IX** is **framework-hardcoded and invariant**: it defines the Eight Prime Directives that make the Atomic Traceability Model work. This is the load-bearing article — every command template, every script, and every knowledge station references Article IX.
+- **Article IX** is **framework-hardcoded and invariant**: it defines the Nine Prime Directives that make the Atomic Traceability Model work. This is the load-bearing article — every command template, every script, and every knowledge station references Article IX.
 - **Article X** is the **Assembly Line Manual** — a pointer to `.specify/knowledge/stations/`, the 18 procedural guides that codify the pipeline.
 
 This split keeps the governance framework stable across projects while letting each project encode its own engineering philosophy in I–VIII.
@@ -329,7 +329,7 @@ These articles are intentionally blank in the shipped constitution template. Pro
 
 These are examples, not mandates. A project can have different Articles I–VIII and still be fully compliant with Atomic Spec — because the governance that makes the framework work lives in Article IX.
 
-#### Article IX: The Eight Prime Directives (Hardcoded)
+#### Article IX: The Nine Prime Directives (Hardcoded)
 
 Article IX is the non-negotiable core. Every command in this framework reads and enforces these directives:
 

--- a/site/src/content/docs/contributing.mdx
+++ b/site/src/content/docs/contributing.mdx
@@ -100,7 +100,7 @@ A few things that increase the odds of acceptance:
 - Update documentation ([README](https://github.com/Chappygo-OS/Atomic-Spec#readme), [Atomic Traceability Model](/Atomic-Spec/docs/atomic-traceability-model), relevant `docs/*.md`) if the change is user-visible
 - Keep the change focused — unrelated fixes should be separate PRs
 - Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
-- Respect the [Eight Prime Directives](/Atomic-Spec/docs/prime-directives) — do not weaken, bypass, or relax them without explicit governance discussion
+- Respect the [Nine Prime Directives](/Atomic-Spec/docs/prime-directives) — do not weaken, bypass, or relax them without explicit governance discussion
 
 ## AI Contributions in Atomic Spec
 

--- a/site/src/content/docs/prime-directives.mdx
+++ b/site/src/content/docs/prime-directives.mdx
@@ -1,9 +1,9 @@
 ---
-title: The Eight Prime Directives
-description: Article IX of the Atomic Spec constitution — the eight non-negotiable rules that turn AI agents from drift-prone collaborators into a governed assembly line.
+title: The Nine Prime Directives
+description: Article IX of the Atomic Spec constitution — the nine non-negotiable rules (Directive 9 added in v0.3) that turn AI agents from drift-prone collaborators into a governed assembly line.
 category: Concepts
 order: 20
-lastUpdated: 2026-04-29
+lastUpdated: 2026-08-21
 ---
 
 The following directives are **NON-NEGOTIABLE** and enforce the "Atomic Traceability" model:
@@ -127,6 +127,7 @@ Registry-eligible decisions include not only the fields explicitly enumerated in
 - CI/CD platform and deployment workflow
 - Package manager and runtime version pins
 - Testing framework (unit / integration / E2E)
+- **Efficiency model-tier mapping** (v0.4+) — coordinator/implementer/HITL model assignments used advisorily by `/atomicspec.implement` and its siblings for tier routing. See the `registry.efficiency` block. Purely advisory in v0.4 (`advisor_enabled: false` by default); measurement primitive and default flip land in v0.4.1.
 
 **Definition of "commit"**: writing config or code that encodes the choice (e.g., creating `docker-compose.yml`, adding a dependency to `package.json`, importing a framework module), OR recording the choice in `plan.md` or a task file as a fixed value. Drafting a comment that *discusses* options is not committing.
 
@@ -211,6 +212,7 @@ Every task file MUST include an "Embedded Context" section containing:
 | **Feature Summary** | `plan.md` (extracted during task generation) | Always |
 | **Gate Criteria** | Subagent/Station gate checklists | When domain knowledge exists |
 | **Structural Decision Triggers** (v0.2+) | Directive 7 scope list | When the task may commit to containerization, deployment, framework, infrastructure provider, or domain primitive — so the implementer recognizes the AskUserQuestion trigger under Context Pinning |
+| **Efficiency Tier Hint** (v0.4+) | Derived at read time from `registry.efficiency.model_tiers` + task phase | Optional; defaults to `implementer` when unset. Advisory only — surfaces which tier the coordinator/implementer/HITL split would apply for this task's phase, without changing task selection or gate logic |
 
 **Graceful Degradation**:
 
@@ -229,3 +231,57 @@ Not all knowledge sources may exist. Handle gracefully:
 **Violation**: Generating task files WITHOUT an Embedded Context section is a Constitution violation. The implementer must have EVERYTHING needed to complete the task without reading forbidden files.
 
 **Rationale**: Subagents during `/atomicspec.implement` are "blind" to stations, subagents, plan.md, and spec.md. Embedding context ensures they follow project patterns instead of guessing.
+
+## Directive 9: Orientation Read Surface (v0.3+)
+
+**Directive 3 (Context Pinning) is unchanged.** This Directive defines a separate, narrower control for the one-shot **Orientation Phase** that runs at the start of `/atomicspec.implement` to detect cross-provider handoff state. It exists as a sibling to Directive 3, not an expansion of it.
+
+**Purpose**: Before any task loop begins, the implementer must detect whether prior work in this feature folder is partially completed (e.g., a Claude session crashed mid-task; a Codex session resumes). Without this detection, a resuming AI silently re-implements work or overwrites half-finished output.
+
+**Scope — enumerated artifacts only**:
+
+The Orientation Phase MAY inspect the following artifacts in the active feature folder, and ONLY these:
+
+- `spec.md`
+- `clarify-log.md` (if present)
+- `plan.md`
+- `index.md`
+- `traceability.md`
+- Every file matching `tasks/T-*.md`
+
+"Any artifact" is not permitted. The list above is exhaustive.
+
+**Permitted read mechanism**:
+
+The Orientation Phase MUST read these artifacts ONLY through the `stamp-lifecycle status` script:
+
+```
+scripts/bash/stamp-lifecycle.sh status --artifact <path>
+scripts/powershell/stamp-lifecycle.ps1 status -Artifact <path>
+```
+
+The script returns JSON describing the Lifecycle Markers block state without exposing surrounding content. **Direct `Read`-tool invocation on `spec.md`, `plan.md`, or `clarify-log.md` body content during Phase 0 is a Constitution violation, regardless of intent.** `index.md` and `traceability.md` may be read directly because Directive 3 already permits them.
+
+**Evidence requirement**:
+
+The Orientation Phase MUST emit its findings as a per-run file under `specs/<feature>/orientation-runs/`, named `<ISO-8601-UTC>-<provider>.md` (e.g., `2026-06-19T15-30-22Z-claude.md`). Each file contains the script's JSON output for every inspected artifact, the outcome (clean / stale / conflict), and the resume decision the user confirmed.
+
+**Why per-run files, not a single appended log**: two providers racing on the same branch (e.g., a crashed Claude session and a fresh Codex session start within seconds) would silently overwrite each other if both prepended to a shared `orientation-runs.md`. Per-run files are append-free and race-free by construction (no two ISO timestamps collide at second precision).
+
+**Enforcement timeline**:
+- **v0.3.0**: the evidence file is REQUIRED by policy. Absence is a Constitution violation but is NOT yet a runtime gate.
+- **v0.3.1**: `check-prerequisites.{sh,ps1} --check-orientation` will inspect `orientation-runs/` for a file matching the current session and BLOCK Phase 1 if absent or stale. Marketed claims about Directive 9 enforcement should reflect this disclosure until v0.3.1 ships.
+
+**Outcomes — exactly three**:
+
+1. **Clean state** — every artifact reports `closed` (or `legacy_closed` for pre-v0.3 artifacts without stamps). Print a single-line summary; proceed to Phase 1. Normal Context Pinning resumes.
+2. **Stale state** — one or more artifacts have an `open` block whose start timestamp is older than the registry's `lifecycle.stale_threshold` (default: 7 days). Surface as informational ("this work appears abandoned"), let the user confirm resume-or-discard. Not blocking.
+3. **Conflict** — one or more artifacts have an `open` block with a start timestamp newer than the stale threshold. STOP, present options menu to user (resume / redo / skip / abort), await confirmation before proceeding.
+
+**Termination**:
+
+Once a task is pinned in Phase 1, the Orientation Phase is finished. Subsequent reads in the session are governed by Directive 3 alone. The Phase 0 carve-out is single-shot, not persistent.
+
+**Violation**: Reading body content of `spec.md`, `plan.md`, or `clarify-log.md` during Phase 0; omitting the `## Orientation Evidence` block from `traceability.md`; or expanding the enumerated artifact scope without a Constitution amendment.
+
+**Rationale**: A governance framework that prevents drift during implementation must also prevent silent failure at session start. The Orientation Phase is the one place where cross-artifact reads are necessary, and isolating it as its own narrow Directive keeps Directive 3 verbatim — preserving the "implementer reads exactly three files" guarantee that the framework's positioning depends on.

--- a/site/src/content/docs/quickstart.mdx
+++ b/site/src/content/docs/quickstart.mdx
@@ -34,7 +34,7 @@ cd atomic-spec
 The initializer copies `.specify/`, `templates/`, slash-command definitions, and the `specs/_defaults/registry.yaml` scaffold into the target project. Supported `--ai` values: `claude`, `gemini`, `copilot`, `cursor`, `windsurf`.
 
 > [!NOTE]
-> A PyPI install (`uv tool install atomic-spec`) is planned for `v0.1.0`. Until then, use the init script above.
+> The PyPI CLI is the preferred install path (`uv tool install atomic-spec` or `pipx install atomic-spec`) — live since v0.2.0. The `init-project.{sh,ps1}` scripts above remain a valid alternative for offline/local setups that use this repo's templates directly.
 
 ### Step 2: Define Your Constitution
 

--- a/site/src/content/docs/support.mdx
+++ b/site/src/content/docs/support.mdx
@@ -29,7 +29,7 @@ Support for this project is limited to the resources listed above.
 Atomic Spec ships template bundles for 17 AI coding agents, organized into two tiers. Issue triage is tier-aware:
 
 - **Supported tier** (`claude`, `gemini`, `copilot`, `cursor-agent`, `windsurf`): bugs are triaged as standard issues. Regressions block releases. See README for the full list.
-- **Experimental tier** (all other agents): command templates are installed into the agent's conventional folder; the Eight Prime Directives remain enforced because they are template-enforced, but agent-specific wiring has not been validated. Issues are labeled `experimental` and triaged best-effort. PRs that promote an agent from experimental to supported — including validation scripts, an entry in `init-project.{sh,ps1}`, and at least one end-to-end smoke run documented in the PR — are welcome.
+- **Experimental tier** (all other agents): command templates are installed into the agent's conventional folder; the Nine Prime Directives remain enforced because they are template-enforced, but agent-specific wiring has not been validated. Issues are labeled `experimental` and triaged best-effort. PRs that promote an agent from experimental to supported — including validation scripts, an entry in `init-project.{sh,ps1}`, and at least one end-to-end smoke run documented in the PR — are welcome.
 
 Requesting a new agent? File an issue with the template tag `agent-request` describing the agent's command-discovery convention and a link to its CLI documentation.
 

--- a/site/src/content/docs/upgrade.mdx
+++ b/site/src/content/docs/upgrade.mdx
@@ -3,7 +3,7 @@ title: Upgrade Guide
 description: Refresh the Atomic Spec CLI and pull the latest framework files into existing projects without losing customizations.
 category: Getting Started
 order: 30
-lastUpdated: 2026-05-18
+lastUpdated: 2026-08-21
 ---
 
 > You have Atomic Spec installed in one or more projects and want to refresh them with the latest framework files (knowledge stations, subagents, templates, slash commands, scripts).
@@ -18,6 +18,64 @@ lastUpdated: 2026-05-18
 | **Framework files in a project (PyPI path)** | `atomicspec init --here --force --ai <agent>` | Refresh templates, commands, scripts |
 | **Framework files in a project (clone path)** | `./init-project.sh /path/to/project --ai <agent>` (re-run) | Alternative if you cloned the repo |
 | **The Atomic Spec source clone** | `git pull origin main` inside your `Atomic-Spec/` checkout | Keep the source tree current before re-running `init-project.sh` |
+
+---
+
+## What Changed in v0.4.0?
+
+v0.4 introduces **advisory model-tier routing**: consumer projects can split coordinator-role turns (Phase 0 orientation, task selection, gate checks, stamp writes) from implementer-role turns (code generation, verification loop) and HITL turns (Directive 6 checkpoints) onto different model tiers. **Fully backwards compatible.** Shipped advisor-off by default; consumer projects on v0.3 see byte-for-byte identical behavior after upgrade until they explicitly flip it.
+
+- **Registry `efficiency:` block (schema 5 → 6)** — new top-level with `model_tiers.{coordinator,implementer,hitl}`, `advisor_enabled: false`, `snapshot_recorded: null`. Governed by Directive 7 — every field is amended via the standard `/atomicspec.registry` HITL flow.
+- **Three new CLI subcommands**:
+  - `atomicspec select-model --phase <coordinator|implementer|hitl>` — machine-readable model lookup. Prints the configured tier or empty on advisor-off; exit code always 0 so bash/PowerShell callers can `MODEL=$(atomicspec select-model ...)` cleanly.
+  - `atomicspec cost snapshot --amount <USD> --provider <name>` — record a single-number cost snapshot. Any provider. Writes `.specify/efficiency-snapshots/<YYYY-MM-DD-HHMMSSuuuuuu>-<scope>.md` with YAML frontmatter.
+  - `atomicspec efficiency report --advisory` — print the tier resolution table + recent snapshots. Header labeled "advisory only, measurement in v0.4.1" verbatim.
+- **Phase 1 Prelude — Efficiency Hint** added to `/atomicspec.specify`, `/plan`, `/tasks`, `/implement` command templates at their Phase 0 anchors. Advisory prose only — does not affect Directive 3 pinning, gate criteria, or downstream steps.
+- **Directive 7 clause amendment** — `efficiency.model_tiers` mapping added to the scope list. **Nine directives stays nine** — clause amendment, not new directive.
+- **Directive 8 companion row** — added "Efficiency Tier Hint" row to the Embedded Context table.
+- **Orientation-run files gain `## Efficiency` H2 section** — `/atomicspec.implement` §0.6 emits `advisor_enabled` state + tier map source + resolved models per phase.
+- **`pyyaml>=6.0,<7`** added to the Python CLI. First YAML lib in the CLI; `safe_load`-only by design (ruff `S506` enforced). Matches upstream `github/spec-kit` and every peer template-distributor CLI.
+- **Full details**: see the [efficiency guide](https://github.com/Chappygo-OS/Atomic-Spec/blob/main/docs/efficiency.md).
+
+### Deliberately deferred to v0.4.1
+
+- **`atomicspec baseline record --feature NNN`** on Claude Code's stable hook API (`Stop` / `PostToolUse` / `SessionEnd`) + Anthropic Console CSV import for API-key users + Codex CLI JSONL adapter (behind separate flag). This is the per-feature measurement primitive that gates the advisor default flip.
+- **Flip `advisor_enabled: true` default** — behind the promotion evidence bar (≥60% of tracked consumer projects show non-empty baselines across ≥2 providers; measured cost reduction ≥15% median; zero P0 governance regressions for 4 weeks).
+
+### Deliberately scope-out for v0.4.x
+
+Cursor / Windsurf / Copilot / Gemini CLI have no equivalent hook API and no path to token-level measurement in v0.4.x. The tier config still applies to them advisorily; they just don't measure. This is honest about a real constraint.
+
+### Migration note
+
+**Fully backwards compatible.** Consumer projects on v0.3 upgrade to v0.4 with no behavior change unless they explicitly flip `advisor_enabled: true` in the new `efficiency:` block. Existing `registry.yaml` files with `version: 5` continue to work — the `check-prerequisites` awk classifier ignores the new top-level. Fresh `atomicspec init` writes `version: 6` with the advisor off. Command templates gain the "Phase 1 Prelude" block; when `advisor_enabled: false`, `atomicspec select-model` returns empty and templates proceed with byte-for-byte v0.3 behavior.
+
+To try the advisor:
+1. Edit `specs/_defaults/registry.yaml`, set `efficiency.advisor_enabled: true`.
+2. (Optional) Replace `model_tiers.*` with provider-native model IDs for OpenAI / Google / etc.
+3. Run any `/atomicspec.*` command — resolved tier appears in orientation evidence.
+
+---
+
+## What Changed in v0.3.0?
+
+v0.3 closes the **cross-provider AI handoff gap**. When Claude crashes mid-feature and you switch to Codex (or hit a quota cliff and fall over to Gemini), the receiving AI now self-orients from files alone — detects which artifacts are half-done, prompts you on conflict, and resumes cleanly without silently overwriting work. A new sibling directive (9) governs this read surface narrowly so Directive 3's Context Pinning stays verbatim.
+
+- **Lifecycle Markers** — every artifact (`spec.md`, `clarify-log.md`, `plan.md`, `index.md`, `traceability.md`, `tasks/T-*.md`) now carries a `## Lifecycle Markers` block recording start/end timestamps and provider names for authoring + implementation lifecycles. Script-managed; AIs MUST NEVER hand-write stamps.
+- **`scripts/{bash,powershell}/stamp-lifecycle.{sh,ps1}`** — deterministic gate for all Lifecycle Markers writes. Subcommands: `init` / `start` / `end` / `status`. 18-provider allowlist, ISO 8601 UTC timestamps, atomic writes.
+- **Article IX, Directive 9: Orientation Read Surface** — a NEW sibling to Directive 3 (Context Pinning). Defines a narrow, single-shot carve-out for the Phase 0 Orientation procedure in `/atomicspec.implement`: read Lifecycle Markers blocks via the status script (NOT direct file reads of `plan.md` / `spec.md` / `clarify-log.md`), classify outcome as Clean / Stale / Conflict, write evidence to `orientation-runs/<ts>-<provider>.md`, present resume menu on conflict via AskUserQuestion. Directive 3 stays verbatim — no governance creep.
+- **Registry schema bump (4 → 5)** — adds `lifecycle.stale_threshold_days` (default 7). Framework-level setting, no HITL gate required.
+- **`clarify-log.md`** (new artifact) + **`scripts/{bash,powershell}/clarify-session-bootstrap.{sh,ps1}`** — clarify is an EDIT to `spec.md`, not a re-author, so `spec.md` is NEVER re-stamped per session. Each clarify run gets its own H2 `## Session <ts>` block in `clarify-log.md`.
+- **Atomic Spec Orientation block** auto-injected into every agent file (CLAUDE.md / GEMINI.md / AGENTS.md / .cursorrules / 12 others) by `scripts/{bash,powershell}/inject-orientation.{sh,ps1}`. Sentinel-versioned; auto-upgrades older blocks; never downgrades newer ones.
+- **`init-project.{sh,ps1}`** substitutes the `{{AGENT_NAME}}` placeholder in command templates with the `--ai` value at copy time.
+
+### Honest disclosure
+
+**Orientation Evidence enforcement** — the current release defines `orientation-runs/<ts>-<provider>.md` as REQUIRED by policy; a runtime gate (`check-prerequisites --check-orientation`) blocking Phase 1 on missing evidence ships in v0.3.1.
+
+### Migration note
+
+**Fully backwards compatible.** v0.2.x projects work without changes. New Lifecycle Markers blocks are added incrementally by command runs; pre-v0.3 artifacts without stamps are treated as `legacy_closed` by the Phase 0 Orientation procedure.
 
 ---
 

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -7,6 +7,7 @@
 #     "platformdirs",
 #     "readchar",
 #     "httpx",
+#     "pyyaml>=6.0,<7",
 # ]
 # ///
 """
@@ -32,6 +33,7 @@ import tempfile
 import shutil
 import shlex
 import json
+from enum import Enum
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -61,7 +63,16 @@ from typer.core import TyperGroup
 import readchar
 import ssl
 import truststore
+import yaml  # v0.4+: registry.yaml parsing for efficiency block; safe_load only
 from datetime import datetime, timezone
+
+# v0.4+: efficiency tier resolver, imported here so both `select-model` and
+# `efficiency report` subcommands share one code path.
+from specify_cli._registry import (
+    VALID_PHASES,
+    load_registry,
+    resolve_tier,
+)
 
 ssl_context = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 client = httpx.Client(verify=ssl_context)
@@ -1326,6 +1337,325 @@ def version():
 
     console.print(panel)
     console.print()
+
+# =============================================================================
+# v0.4+ EFFICIENCY SUBCOMMANDS
+# =============================================================================
+# `atomicspec select-model` — machine-readable model lookup for command
+# templates. `atomicspec cost snapshot` — record a single-number cost snapshot
+# from any provider/source. `atomicspec efficiency report --advisory` — print
+# tier resolution + recent snapshots. All advisory in v0.4; per-feature
+# measurement lands in v0.4.1.
+# =============================================================================
+
+cost_app = typer.Typer(
+    name="cost",
+    help="Cost tracking (v0.4+). Advisory single-number snapshots; per-feature measurement lands in v0.4.1.",
+    add_completion=False,
+)
+efficiency_app = typer.Typer(
+    name="efficiency",
+    help="Efficiency reporting (v0.4+). Advisory only in v0.4.",
+    add_completion=False,
+)
+
+
+class Phase(str, Enum):
+    """Valid `--phase` values for `atomicspec select-model`.
+
+    Backed by str so `Phase.coordinator.value == "coordinator"` and callers
+    can pass the enum through to `resolve_tier` without unwrapping. Typer
+    validates the choice at parse time — a typo like `--phase coord`
+    fails loudly with a helpful message rather than silently returning empty.
+    """
+
+    coordinator = "coordinator"
+    implementer = "implementer"
+    hitl = "hitl"
+
+
+@app.command("select-model")
+def select_model(
+    phase: Phase = typer.Option(
+        ...,
+        "--phase",
+        help="Turn phase to resolve: coordinator, implementer, or hitl.",
+    ),
+) -> None:
+    """Print the advisory model for a phase, or empty on disabled/missing.
+
+    Machine-readable: prints the model name + trailing newline on stdout when
+    advisor is on and the tier is set; prints an empty line otherwise. Exit
+    code is always 0 so callers in bash/PowerShell can `MODEL=$(atomicspec ...)`
+    and branch on `[ -n "$MODEL" ]` without special-casing.
+    """
+    resolution = resolve_tier(phase.value)
+    typer.echo(resolution.model or "")
+
+
+@cost_app.command("snapshot")
+def cost_snapshot(
+    amount: float = typer.Option(
+        ..., "--amount", help="Cost in USD for this snapshot (e.g., 1.50)."
+    ),
+    provider: str = typer.Option(
+        ..., "--provider", help="Provider label: anthropic | openai | google | other."
+    ),
+    source: str = typer.Option(
+        "paste",
+        "--source",
+        help="Where the amount came from: paste | jsonl | csv | other.",
+    ),
+    feature: Optional[str] = typer.Option(
+        None,
+        "--feature",
+        help="Optional feature identifier (e.g., 042). Recorded as ad hoc if omitted.",
+    ),
+    tokens: Optional[int] = typer.Option(
+        None, "--tokens", help="Optional token count for provenance."
+    ),
+    note: Optional[str] = typer.Option(
+        None, "--note", help="Free-text note describing the measurement context."
+    ),
+) -> None:
+    """Record a cost snapshot to .specify/efficiency-snapshots/<date>-<scope>.md.
+
+    Atomic-write pattern (`.tmp` → rename). YAML frontmatter carries the
+    numeric fields; prose section is human-readable summary. Snapshots are
+    advisory only — not per-turn measurement.
+    """
+    show_banner()
+
+    cwd = Path.cwd()
+    snapshots_dir = cwd / ".specify" / "efficiency-snapshots"
+    snapshots_dir.mkdir(parents=True, exist_ok=True)
+
+    now = datetime.now(timezone.utc)
+    date_slug = now.strftime("%Y-%m-%d")
+    # HHMMSS + microseconds so same-day+same-scope runs do NOT silently overwrite
+    # the previous snapshot even when a script batch-records within a single
+    # second. This is the "record every paste" contract the docs promise; users
+    # reconciling Anthropic Console entries need every snapshot preserved.
+    time_slug = now.strftime("%H%M%S") + f"{now.microsecond:06d}"
+    feature_slug = f"feature-{feature}" if feature else "adhoc"
+    filename = f"{date_slug}-{time_slug}-{feature_slug}.md"
+    target = snapshots_dir / filename
+
+    frontmatter = {
+        "kind": "efficiency-snapshot",
+        "schema_version": 1,
+        "recorded_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "feature": feature,
+        "provider": provider,
+        "source": source,
+        "amount_usd": amount,
+        "tokens": tokens,
+        "note": note,
+    }
+
+    # yaml.safe_dump handles every YAML-special character correctly: Windows
+    # paths (`C:\Users\x` where `\U` would otherwise be a double-quoted YAML
+    # unicode escape), newlines, colons, quotes, backticks, and unicode.
+    # Hand-rolled quoting was a Windows landmine and dropped newlines silently.
+    # sort_keys=False preserves the order set above so recorded_at reads first.
+    fm_text = yaml.safe_dump(
+        frontmatter,
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+    )
+    lines: list[str] = ["---", fm_text.rstrip(), "---", ""]
+    scope_label = f"feature {feature}" if feature else "ad hoc"
+    lines.append(f"# Cost Snapshot — {scope_label}")
+    lines.append("")
+    lines.append(
+        f"Recorded on {date_slug} for provider `{provider}` from source `{source}`."
+    )
+    lines.append("")
+    lines.append(f"**Amount**: ${amount:.2f} USD")
+    if tokens is not None:
+        lines.append(f"**Tokens**: {tokens}")
+    if note:
+        # Preserve multi-line notes verbatim by rendering as a fenced block
+        # rather than collapsing to a single line. Normalize CRLF → LF first.
+        normalized_note = note.replace("\r\n", "\n").replace("\r", "\n")
+        if "\n" in normalized_note:
+            lines.append("**Note**:")
+            lines.append("")
+            lines.append("```")
+            lines.extend(normalized_note.split("\n"))
+            lines.append("```")
+        else:
+            lines.append(f"**Note**: {normalized_note}")
+    lines.append("")
+    lines.append("---")
+    lines.append(
+        "*Advisory data. This snapshot is not a per-turn measurement. "
+        "Per-feature measurement primitive lands in v0.4.1.*"
+    )
+    lines.append("")
+    body = "\n".join(lines)
+
+    tmp_path = target.with_suffix(target.suffix + ".tmp")
+    tmp_path.write_text(body, encoding="utf-8")
+    tmp_path.replace(target)
+
+    console.print(f"[green]Snapshot written:[/green] {target.relative_to(cwd)}")
+    console.print()
+    console.print(
+        "[dim]Use `atomicspec efficiency report --advisory` to see all snapshots.[/dim]"
+    )
+
+
+@efficiency_app.command("report")
+def efficiency_report(
+    advisory: bool = typer.Option(
+        False,
+        "--advisory",
+        help="Print the advisory tier resolution table. Required in v0.4 (only supported mode).",
+    ),
+    feature: Optional[str] = typer.Option(
+        None, "--feature", help="Filter snapshot listing to this feature identifier."
+    ),
+    limit: int = typer.Option(
+        5, "--limit", help="Number of most-recent snapshots to display."
+    ),
+) -> None:
+    """Print the advisory tier map and recent cost snapshots.
+
+    v0.4 supports `--advisory` only. Full per-feature measurement lands in
+    v0.4.1. Output is labeled "advisory only" so it never reads as
+    authoritative billing evidence.
+    """
+    show_banner()
+
+    if not advisory:
+        console.print(
+            "[yellow]v0.4 only supports `--advisory` mode.[/yellow] "
+            "Full measurement lands in v0.4.1."
+        )
+        console.print("Re-run: [cyan]atomicspec efficiency report --advisory[/cyan]")
+        raise typer.Exit(1)
+
+    registry = load_registry()
+    console.print(
+        "[bold]Advisory tier resolution[/bold] "
+        "[dim](advisory only — measurement in v0.4.1)[/dim]"
+    )
+    console.print()
+
+    tier_table = Table(show_header=True, header_style="bold cyan")
+    tier_table.add_column("Phase")
+    tier_table.add_column("Advisor")
+    tier_table.add_column("Configured model")
+    tier_table.add_column("Reason")
+
+    for phase in VALID_PHASES:
+        resolution = resolve_tier(phase, registry)
+        model_cell = resolution.model or "[dim]—[/dim]"
+        advisor_cell = (
+            "[green]on[/green]" if resolution.advisor_enabled else "[dim]off[/dim]"
+        )
+        tier_table.add_row(phase, advisor_cell, model_cell, resolution.reason)
+
+    console.print(tier_table)
+    console.print()
+
+    snapshots_dir = Path.cwd() / ".specify" / "efficiency-snapshots"
+    if not snapshots_dir.is_dir():
+        console.print(
+            "[dim]No snapshots recorded yet.[/dim] "
+            "Use `atomicspec cost snapshot` to record one."
+        )
+        return
+
+    # Load every snapshot's frontmatter once, then sort by recorded_at (which
+    # is monotonic and precise) rather than filename (alphabetical). Skips
+    # files whose frontmatter fails to parse — those render nowhere. The
+    # `--feature NNN` filter matches against the parsed feature field, not
+    # the filename suffix, so it does not collide on "42" vs "042" vs "1042".
+    all_snaps: list[tuple[Path, dict]] = []
+    for path in snapshots_dir.glob("*.md"):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        meta = _parse_snapshot_frontmatter(text)
+        if not meta:
+            continue
+        all_snaps.append((path, meta))
+
+    all_snaps.sort(
+        key=lambda item: str(item[1].get("recorded_at") or item[0].name),
+        reverse=True,
+    )
+
+    if feature:
+        all_snaps = [
+            (p, m) for (p, m) in all_snaps if str(m.get("feature") or "") == feature
+        ]
+
+    if not all_snaps:
+        console.print("[dim]No matching snapshots.[/dim]")
+        return
+
+    snap_table = Table(
+        title=f"Recent snapshots (last {min(limit, len(all_snaps))})",
+        show_header=True,
+        header_style="bold cyan",
+    )
+    snap_table.add_column("Date")
+    snap_table.add_column("Scope")
+    snap_table.add_column("Provider")
+    snap_table.add_column("Amount")
+    snap_table.add_column("Source")
+
+    for _, meta in all_snaps[:limit]:
+        scope = f"feature {meta['feature']}" if meta.get("feature") else "ad hoc"
+        snap_table.add_row(
+            str(meta.get("recorded_at", "?")),
+            scope,
+            str(meta.get("provider", "?")),
+            f"${meta.get('amount_usd', '?')}",
+            str(meta.get("source", "?")),
+        )
+
+    console.print(snap_table)
+
+
+def _parse_snapshot_frontmatter(text: str) -> dict:
+    """Extract YAML frontmatter from a snapshot file. Returns {} on failure.
+
+    Tolerates a leading UTF-8 BOM (``\\ufeff``) on the first line so files
+    re-saved by BOM-adding editors (Notepad, some VS Code configs) still
+    parse. ``str.strip()`` does not remove ``\\ufeff`` on its own, so we
+    strip it explicitly before the ``---`` delimiter check.
+    """
+    lines = text.splitlines()
+    if lines:
+        lines[0] = lines[0].lstrip("﻿")
+    if not lines or lines[0].strip() != "---":
+        return {}
+    body: list[str] = []
+    closed = False
+    for line in lines[1:]:
+        if line.strip() == "---":
+            closed = True
+            break
+        body.append(line)
+    if not closed:
+        return {}
+    try:
+        parsed = yaml.safe_load("\n".join(body))
+    except yaml.YAMLError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+# Register subcommand groups. Must run after group definitions but before main().
+app.add_typer(cost_app, name="cost")
+app.add_typer(efficiency_app, name="efficiency")
+
 
 def main():
     app()

--- a/src/specify_cli/_registry.py
+++ b/src/specify_cli/_registry.py
@@ -1,0 +1,157 @@
+"""Registry reader for the v0.4+ efficiency block.
+
+Reads `specs/_defaults/registry.yaml` and exposes two helpers used by the
+`select-model`, `cost snapshot`, and `efficiency report` subcommands:
+
+- `load_registry()`: safe YAML parse of the project's Defaults Registry.
+- `resolve_tier()`: given a phase (coordinator/implementer/hitl), return the
+   configured model name or None when the advisor is disabled or missing.
+
+Design constraints (baked in, not opt-in):
+- `yaml.safe_load` ONLY. Never `yaml.load`. Every 2024-2026 PyYAML CVE is a
+  `yaml.load()` deserialization attack; `safe_load` is immune.
+- Read-only. Writes to the registry stay in shell (atomic-write pattern
+  documented at `templates/commands/_registry-protocol.md`). A future
+  `ruamel.yaml` migration for roundtrip-safe writes is a v0.5+ decision.
+- Graceful degradation. Missing file / missing block / malformed YAML never
+  raises to callers - it returns an empty view. Directive 7's protocol says
+  commands must handle missing knowledge sources without failing hard.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import yaml
+
+Phase = Literal["coordinator", "implementer", "hitl"]
+
+# Ordered by v0.4 promotion path. Update in lockstep with the registry
+# template if new tiers are added.
+VALID_PHASES: tuple[str, ...] = ("coordinator", "implementer", "hitl")
+
+REGISTRY_RELATIVE_PATH = Path("specs") / "_defaults" / "registry.yaml"
+
+
+@dataclass(frozen=True)
+class TierResolution:
+    """Result of resolving a phase against the efficiency block.
+
+    `model` is None when `advisor_enabled: false`, the block is missing, or
+    the specific phase key is unset. `reason` is a human-readable diagnostic
+    used by `atomicspec efficiency report --advisory`.
+    """
+
+    phase: str
+    model: str | None
+    advisor_enabled: bool
+    reason: str
+
+
+def _find_registry_path(start: Path | None = None) -> Path | None:
+    """Walk upward from `start` (default: cwd) looking for `specs/_defaults/registry.yaml`.
+
+    Returns the resolved path or None. Matches the resolution strategy used
+    by the shell `check-prerequisites` helpers, but pure Python.
+    """
+    current = (start or Path.cwd()).resolve()
+    for candidate in (current, *current.parents):
+        target = candidate / REGISTRY_RELATIVE_PATH
+        if target.is_file():
+            return target
+    return None
+
+
+def load_registry(start: Path | None = None) -> dict:
+    """Return the parsed registry as a dict, or {} if missing / malformed.
+
+    Uses `yaml.safe_load` exclusively. Graceful on every failure mode:
+    missing file, empty file, malformed YAML, or non-mapping root. The
+    caller downstream distinguishes "no registry" from "no efficiency
+    block" via presence of `efficiency` key.
+    """
+    path = _find_registry_path(start)
+    if path is None:
+        return {}
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    try:
+        parsed = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return parsed
+
+
+def resolve_tier(phase: str, registry: dict | None = None) -> TierResolution:
+    """Resolve a phase name to the configured model, honoring `advisor_enabled`.
+
+    Returns a `TierResolution` regardless of outcome so callers can render a
+    diagnostic table without special-casing missing state.
+
+    Contract:
+      - Unknown phase → model=None, reason="unknown-phase"
+      - No registry file → model=None, reason="registry-missing"
+      - No efficiency block → model=None, reason="efficiency-block-missing"
+      - `advisor_enabled: false` → model=None, reason="advisor-disabled"
+      - Phase key null / empty → model=None, reason="tier-unset"
+      - Advisor on, phase set → model=<string>, reason="resolved"
+    """
+    if phase not in VALID_PHASES:
+        return TierResolution(
+            phase=phase, model=None, advisor_enabled=False, reason="unknown-phase"
+        )
+    reg = registry if registry is not None else load_registry()
+    if not reg:
+        return TierResolution(
+            phase=phase, model=None, advisor_enabled=False, reason="registry-missing"
+        )
+    efficiency = reg.get("efficiency")
+    if not isinstance(efficiency, dict):
+        return TierResolution(
+            phase=phase,
+            model=None,
+            advisor_enabled=False,
+            reason="efficiency-block-missing",
+        )
+    # Strict bool check — NOT `bool(...)`. If a user quoted the value in YAML
+    # (`advisor_enabled: 'false'`), pyyaml returns the STRING "false", and
+    # `bool("false")` is True — which would silently flip the master switch ON
+    # for a user who typed the config intending to keep it off. Only accept
+    # a real YAML boolean.
+    raw_advisor = efficiency.get("advisor_enabled", False)
+    advisor_enabled = raw_advisor is True
+    if not advisor_enabled:
+        return TierResolution(
+            phase=phase,
+            model=None,
+            advisor_enabled=False,
+            reason="advisor-disabled",
+        )
+    tiers = efficiency.get("model_tiers")
+    if not isinstance(tiers, dict):
+        return TierResolution(
+            phase=phase,
+            model=None,
+            advisor_enabled=True,
+            reason="tier-map-missing",
+        )
+    model = tiers.get(phase)
+    if not isinstance(model, str) or not model.strip():
+        return TierResolution(
+            phase=phase,
+            model=None,
+            advisor_enabled=True,
+            reason="tier-unset",
+        )
+    return TierResolution(
+        phase=phase,
+        model=model.strip(),
+        advisor_enabled=True,
+        reason="resolved",
+    )

--- a/templates/commands/implement.md
+++ b/templates/commands/implement.md
@@ -42,6 +42,14 @@ Per Constitution Article IX, Directive 3, during implementation you are:
 
 The orientation is the cross-provider handoff substrate. Skipping it is a Constitution violation.
 
+#### 0.0 Phase 1 Prelude — Efficiency Hint (v0.4+) _(advisory)_
+
+Run: `atomicspec select-model --phase coordinator`
+
+If a non-empty model name is printed, the project has configured an advisory tier for coordinator-role turns like this Phase 0 Orientation sweep; agents that support per-turn model selection (Claude Code subagent `Task` tool) MAY honor it. When Phase 1 begins and actual task work starts, re-run with `--phase implementer` for the implementer tier. If the command prints nothing, `advisor_enabled` is `false` (v0.4 default) — proceed with default behavior; byte-for-byte v0.3 compatibility is preserved.
+
+**This surface is advisory only.** It does not widen Directive 3 pinning, does not permit reading `plan.md` / `spec.md` / `clarify-log.md` body content, and does not affect the stamp-lifecycle enumeration below. `atomicspec select-model` reads ONLY `specs/_defaults/registry.yaml`, which is not a Directive-3-restricted artifact. Record the resolved model in §0.6's Orientation Evidence file under the `## Efficiency` section. Per-feature measurement lands in v0.4.1.
+
 #### 0.1 Locate the active feature folder
 
 ```bash
@@ -205,7 +213,26 @@ Each run file follows the structure from `templates/orientation-runs-template.md
 ## Decision
 
 <Proceeded to Phase 1 | Resumed T-007 from prior session | Discarded prior work on T-007 (redo) | User aborted>
+
+## Efficiency (v0.4+)
+
+- advisor_enabled: <true|false>
+- tier_map_source: specs/_defaults/registry.yaml
+- provider_detected: {{AGENT_NAME}}
+- notes: advisory only; per-feature measurement lands in v0.4.1
 ```
+
+<!--
+  Why only advisor state + registry pointer, not resolved tier values:
+  the tier map is derived from the registry at read time by v0.4.1
+  measurement tooling; persisting a snapshot of it here would guarantee
+  bit-rot when the registry changes. This block's job in v0.4 is to give
+  a v0.4.1 hook-based baseline reader an unambiguous "was the advisor on
+  during this run, and where should I look up its tier map?" — nothing
+  more. Do NOT expand this to record which model actually ran; that's
+  what the hook API returns, not what the framework can honestly claim.
+-->
+
 
 **Status of enforcement (v0.3 honest disclosure)**: this evidence is REQUIRED by Directive 9, but the wiring that BLOCKS Phase 1 on missing evidence (`check-prerequisites.sh --check-orientation`) ships in v0.3.1, not v0.3.0. For v0.3.0, missing or stale evidence is a Constitution violation by policy but NOT a hard gate. The forthcoming v0.3.1 hardening will make this a runtime block.
 

--- a/templates/commands/plan.md
+++ b/templates/commands/plan.md
@@ -232,6 +232,14 @@ Store configuration in plan.md:
 
 Before any planning work, load the project defaults registry:
 
+**Phase 1 Prelude — Efficiency Hint (v0.4+)** _(advisory)_
+
+Run: `atomicspec select-model --phase coordinator`
+
+If a non-empty model name is printed, the project has configured an advisory tier for coordinator-role turns like this Phase 0.x work; agents that support per-turn model selection (Claude Code subagent `Task` tool) MAY honor it. When Phase 1 begins (Technical Context, architecture drafting, actual planning), re-run with `--phase implementer` for that phase's advisory tier. For HITL checkpoints (Phase 0.5, 0.7, 0.8, 0.9), `--phase hitl` applies. If the command prints nothing, `advisor_enabled` is `false` (v0.4 default) — proceed with default behavior; byte-for-byte v0.3 compatibility is preserved.
+
+Advisory only: does not affect Directive 3 pinning, gate criteria, or the HITL checkpoints below. Per-feature measurement lands in v0.4.1.
+
 1. **Read registry file**:
    ```
    Read: specs/_defaults/registry.yaml

--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -69,6 +69,14 @@ Given that feature description, do this:
 
    **NOTE**: Downstream commands (`/atomicspec.plan`, `/atomicspec.build`, etc.) will inherit this platform setting from the spec. This ensures consistent platform context throughout the entire feature lifecycle.
 
+0.5. **Phase 1 Prelude — Efficiency Hint (v0.4+)** _(advisory)_
+
+   Run: `atomicspec select-model --phase coordinator`
+
+   If a non-empty model name is printed (e.g., `claude-haiku-4-5`), the project has configured an advisory tier for coordinator-role turns like this one; agents that support per-turn model selection (Claude Code subagent `Task` tool) MAY honor it. If the command prints nothing, `registry.efficiency.advisor_enabled` is `false` (v0.4 default) or the efficiency block is absent — proceed with default behavior. Byte-for-byte v0.3 compatibility is preserved in the empty case.
+
+   Advisory only: does not affect Directive 3 pinning, gate criteria, or any downstream step. Per-feature measurement lands in v0.4.1.
+
 1. **Check Project Defaults Registry** (per Constitution Directive 7):
 
    Read `specs/_defaults/registry.yaml` to check for existing project defaults.

--- a/templates/commands/tasks.md
+++ b/templates/commands/tasks.md
@@ -48,6 +48,14 @@ Run `{SCRIPT}` from repo root. This script will:
 
 If the script outputs gate failures, report them to the user and **DO NOT PROCEED**.
 
+### 1.25 Phase 1 Prelude — Efficiency Hint (v0.4+) _(advisory)_
+
+Run: `atomicspec select-model --phase coordinator`
+
+If a non-empty model name is printed, the project has configured an advisory tier for coordinator-role turns like task generation; agents that support per-turn model selection (Claude Code subagent `Task` tool) MAY honor it. If the command prints nothing, `advisor_enabled` is `false` (v0.4 default) — proceed with default behavior; byte-for-byte v0.3 compatibility is preserved.
+
+Advisory only: does not affect Directive 3 pinning (task generation is not yet under Context Pinning; that begins at `/atomicspec.implement`), gate criteria, atomic task naming (Directive 2), or embedded-context generation (Directive 8). Per-feature measurement lands in v0.4.1.
+
 ### 1.5 Load Project Defaults Registry
 
 **Per Constitution Article IX, Directive 7 - Load registry before generating tasks.**

--- a/templates/registry-template.yaml
+++ b/templates/registry-template.yaml
@@ -9,7 +9,7 @@
 # Updates require HITL (Human-In-The-Loop) approval via AskUserQuestion
 # ============================================================================
 
-version: 5
+version: 6
 created: null  # Set when first decision is added
 last_updated: null
 last_updated_by: null
@@ -831,6 +831,47 @@ compliance:
   # Data residency requirement: <region> | none
   # e.g., 'eu-only', 'us-only', 'in-only' (India), 'multi-region'
   data_residency: null
+
+# ============================================================================
+# EFFICIENCY (v0.4+)
+# ============================================================================
+# Advisory tier routing for coordination/implementation/HITL turns during
+# /atomicspec.implement (and its siblings). Governed by Directive 7 (Project
+# Defaults Registry). Amend via /atomicspec.registry — the same HITL protocol
+# that guards every other decision here.
+#
+# Purely advisory in v0.4: agents that support per-turn model selection
+# (Claude Code subagent Task tool) may honor these; other agents record the
+# resolved tier in orientation-run evidence but continue on their default
+# model. Measurement primitive (baseline record) lands in v0.4.1.
+#
+# NAMING NOTE: this efficiency.model_tiers is the PHASE-TIER concept (which
+# model runs which kind of turn). It is semantically distinct from the
+# per-subagent `model:` frontmatter hint in `.specify/subagents/**/*.md`,
+# which pins a model for one named subagent regardless of phase.
+# ============================================================================
+efficiency:
+  # Advisory tier map. Values are provider-native model IDs, not aliases.
+  # Consumer projects on non-Anthropic providers replace these via
+  # /atomicspec.registry — the tier semantics (coord/impl/hitl) stay stable.
+  model_tiers:
+    # Coordinator turns: Phase 0 orientation, task selection from index.md,
+    # gate criteria evaluation, stamp-lifecycle writes, traceability updates.
+    coordinator: claude-haiku-4-5
+    # Implementer turns: task-body work, code generation, verification loop.
+    implementer: claude-sonnet-4-6
+    # HITL turns: Directive 6 checkpoints, ambiguous decisions, plan-phase
+    # judgment calls. Also a good fit for adversarial review passes.
+    hitl: claude-opus-4-7
+
+  # Master switch. v0.4 ships false (behavior-preserving; no consumer project
+  # sees any change until they flip this). v0.4.1 flips the default to true
+  # once the evidence bar in the v0.4 → v0.4.1 promotion gate is met.
+  advisor_enabled: false
+
+  # ISO-8601 UTC of the last `atomicspec cost snapshot` run for this project.
+  # `atomicspec efficiency report --advisory` uses it to warn on stale data.
+  snapshot_recorded: null
 
 # ============================================================================
 # FEATURE TRACKING

--- a/tests/test_registry_efficiency.py
+++ b/tests/test_registry_efficiency.py
@@ -1,0 +1,140 @@
+"""Smoke tests for the v0.4+ registry efficiency reader.
+
+Scope: verify `load_registry()` returns the expected shape given a fixture
+registry, and `resolve_tier()` honors `advisor_enabled` + graceful-degradation
+contract. Full pytest+CI wiring is deferred to v0.4.1; these two files exist
+so a maintainer can `pytest tests/` and see the invariants under test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from specify_cli._registry import (
+    VALID_PHASES,
+    load_registry,
+    resolve_tier,
+)
+
+
+REGISTRY_ADVISOR_ON = """\
+version: 6
+efficiency:
+  model_tiers:
+    coordinator: claude-haiku-4-5
+    implementer: claude-sonnet-4-6
+    hitl:        claude-opus-4-7
+  advisor_enabled: true
+"""
+
+REGISTRY_ADVISOR_OFF = """\
+version: 6
+efficiency:
+  model_tiers:
+    coordinator: claude-haiku-4-5
+    implementer: claude-sonnet-4-6
+    hitl:        claude-opus-4-7
+  advisor_enabled: false
+"""
+
+REGISTRY_MISSING_EFFICIENCY = """\
+version: 6
+architecture:
+  pattern: monolith
+"""
+
+REGISTRY_MALFORMED = "this is: : malformed: yaml: [\nnot: closed"
+
+
+def _lay_out(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, text: str) -> Path:
+    (tmp_path / "specs" / "_defaults").mkdir(parents=True)
+    (tmp_path / "specs" / "_defaults" / "registry.yaml").write_text(
+        text, encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_load_registry_missing_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert load_registry() == {}
+
+
+def test_load_registry_valid_shape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _lay_out(tmp_path, monkeypatch, REGISTRY_ADVISOR_ON)
+    reg = load_registry()
+    assert reg["version"] == 6
+    assert reg["efficiency"]["advisor_enabled"] is True
+    assert reg["efficiency"]["model_tiers"]["coordinator"] == "claude-haiku-4-5"
+    assert reg["efficiency"]["model_tiers"]["implementer"] == "claude-sonnet-4-6"
+    assert reg["efficiency"]["model_tiers"]["hitl"] == "claude-opus-4-7"
+
+
+def test_load_registry_malformed_returns_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _lay_out(tmp_path, monkeypatch, REGISTRY_MALFORMED)
+    assert load_registry() == {}
+
+
+def test_resolve_tier_advisor_on(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _lay_out(tmp_path, monkeypatch, REGISTRY_ADVISOR_ON)
+    result = resolve_tier("coordinator")
+    assert result.model == "claude-haiku-4-5"
+    assert result.advisor_enabled is True
+    assert result.reason == "resolved"
+
+
+def test_resolve_tier_advisor_off(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _lay_out(tmp_path, monkeypatch, REGISTRY_ADVISOR_OFF)
+    result = resolve_tier("coordinator")
+    assert result.model is None
+    assert result.advisor_enabled is False
+    assert result.reason == "advisor-disabled"
+
+
+def test_resolve_tier_missing_efficiency_block(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _lay_out(tmp_path, monkeypatch, REGISTRY_MISSING_EFFICIENCY)
+    result = resolve_tier("coordinator")
+    assert result.model is None
+    assert result.reason == "efficiency-block-missing"
+
+
+def test_resolve_tier_unknown_phase(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _lay_out(tmp_path, monkeypatch, REGISTRY_ADVISOR_ON)
+    result = resolve_tier("something-weird")
+    assert result.model is None
+    assert result.reason == "unknown-phase"
+
+
+def test_resolve_tier_missing_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = resolve_tier("coordinator")
+    assert result.model is None
+    assert result.reason == "registry-missing"
+
+
+def test_resolve_tier_all_valid_phases(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _lay_out(tmp_path, monkeypatch, REGISTRY_ADVISOR_ON)
+    for phase in VALID_PHASES:
+        result = resolve_tier(phase)
+        assert result.model is not None, f"phase {phase} should resolve"
+        assert result.reason == "resolved"

--- a/tests/test_select_model.py
+++ b/tests/test_select_model.py
@@ -1,0 +1,84 @@
+"""End-to-end smoke test for the `atomicspec select-model` subcommand.
+
+Uses Typer's CliRunner so the test exercises the full command wiring (option
+parsing, exit code contract, stdout format). See `test_registry_efficiency.py`
+for the underlying `_registry` module unit tests.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from specify_cli import app
+
+runner = CliRunner()
+
+
+REGISTRY_ADVISOR_ON = """\
+version: 6
+efficiency:
+  model_tiers:
+    coordinator: claude-haiku-4-5
+    implementer: claude-sonnet-4-6
+    hitl:        claude-opus-4-7
+  advisor_enabled: true
+"""
+
+REGISTRY_ADVISOR_OFF = REGISTRY_ADVISOR_ON.replace(
+    "advisor_enabled: true", "advisor_enabled: false"
+)
+
+
+def _lay_out_project(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, registry_yaml: str
+) -> None:
+    (tmp_path / "specs" / "_defaults").mkdir(parents=True)
+    (tmp_path / "specs" / "_defaults" / "registry.yaml").write_text(
+        registry_yaml, encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+
+
+def test_select_model_prints_model_when_advisor_on(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _lay_out_project(tmp_path, monkeypatch, REGISTRY_ADVISOR_ON)
+    result = runner.invoke(app, ["select-model", "--phase", "coordinator"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "claude-haiku-4-5"
+
+
+def test_select_model_prints_empty_when_advisor_off(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _lay_out_project(tmp_path, monkeypatch, REGISTRY_ADVISOR_OFF)
+    result = runner.invoke(app, ["select-model", "--phase", "coordinator"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == ""
+
+
+def test_select_model_prints_empty_when_registry_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["select-model", "--phase", "coordinator"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == ""
+
+
+def test_select_model_all_three_phases_resolve(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _lay_out_project(tmp_path, monkeypatch, REGISTRY_ADVISOR_ON)
+    expected = {
+        "coordinator": "claude-haiku-4-5",
+        "implementer": "claude-sonnet-4-6",
+        "hitl": "claude-opus-4-7",
+    }
+    for phase, model in expected.items():
+        result = runner.invoke(app, ["select-model", "--phase", phase])
+        assert result.exit_code == 0, f"phase {phase} failed: {result.output}"
+        assert result.stdout.strip() == model

--- a/tests/test_v04_regressions.py
+++ b/tests/test_v04_regressions.py
@@ -1,0 +1,294 @@
+"""Regression tests for v0.4 review-panel findings.
+
+Every test here covers a specific bug that shipped in the first-draft
+v0.4 code and was fixed after adversarial review:
+
+- Quoted 'false' silently flipping advisor ON (bool coercion)
+- Windows path in --note corrupting the snapshot (YAML \\U escape)
+- Multi-line --note collapsing to a single line
+- BOM-prefixed snapshots ignored by the report
+- Same-day + same-scope snapshot filename collision (silent overwrite)
+- --phase typo silently succeeding with empty output
+- Report sorting alphabetically by filename instead of by recorded_at
+- Feature filter collision on "42" vs "042" vs "1042"
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from specify_cli import app, _parse_snapshot_frontmatter
+from specify_cli._registry import resolve_tier
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Advisor bool coercion (regression: bool("false") == True)
+# ---------------------------------------------------------------------------
+
+
+def _write_registry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, yaml_text: str) -> None:
+    (tmp_path / "specs" / "_defaults").mkdir(parents=True)
+    (tmp_path / "specs" / "_defaults" / "registry.yaml").write_text(
+        yaml_text, encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "quoted_value",
+    ["'false'", '"false"', "'no'", '"no"', "'off'"],
+)
+def test_advisor_enabled_quoted_string_stays_off(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, quoted_value: str
+) -> None:
+    """Quoted YAML strings must NOT flip advisor on regardless of Python bool()."""
+    _write_registry(
+        tmp_path,
+        monkeypatch,
+        f"""\
+version: 6
+efficiency:
+  model_tiers:
+    coordinator: claude-haiku-4-5
+    implementer: claude-sonnet-4-6
+    hitl: claude-opus-4-7
+  advisor_enabled: {quoted_value}
+""",
+    )
+    result = resolve_tier("coordinator")
+    assert result.model is None, (
+        f"advisor_enabled: {quoted_value} must not resolve a tier; "
+        f"got {result.model!r} with reason {result.reason!r}"
+    )
+    assert result.advisor_enabled is False
+
+
+def test_advisor_enabled_int_1_stays_off(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Integer 1 in the switch position must not enable the advisor either."""
+    _write_registry(
+        tmp_path,
+        monkeypatch,
+        """\
+version: 6
+efficiency:
+  model_tiers:
+    coordinator: claude-haiku-4-5
+    implementer: claude-sonnet-4-6
+    hitl: claude-opus-4-7
+  advisor_enabled: 1
+""",
+    )
+    result = resolve_tier("coordinator")
+    assert result.model is None
+
+
+def test_advisor_enabled_real_true_still_works(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Sanity check: an unquoted `true` still enables the advisor."""
+    _write_registry(
+        tmp_path,
+        monkeypatch,
+        """\
+version: 6
+efficiency:
+  model_tiers:
+    coordinator: claude-haiku-4-5
+    implementer: claude-sonnet-4-6
+    hitl: claude-opus-4-7
+  advisor_enabled: true
+""",
+    )
+    result = resolve_tier("coordinator")
+    assert result.model == "claude-haiku-4-5"
+    assert result.advisor_enabled is True
+
+
+# ---------------------------------------------------------------------------
+# select-model --phase validation (regression: typo silently returned empty)
+# ---------------------------------------------------------------------------
+
+
+def test_select_model_rejects_unknown_phase(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A typo in --phase must fail with non-zero exit + Typer error, not silent empty."""
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["select-model", "--phase", "coord"])
+    assert result.exit_code != 0, (
+        f"expected non-zero exit for typo phase; got {result.exit_code} "
+        f"with stdout={result.stdout!r}"
+    )
+    combined = (result.stdout + (result.stderr or "")).lower()
+    assert (
+        "coord" in combined
+        or "invalid" in combined
+        or "choose from" in combined
+        or "not one of" in combined
+    ), f"expected helpful error, got {result.output!r}"
+
+
+# ---------------------------------------------------------------------------
+# cost snapshot: Windows paths and multiline notes (regression: YAML escape)
+# ---------------------------------------------------------------------------
+
+
+def _run_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, note: str
+) -> Path:
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "cost",
+            "snapshot",
+            "--amount",
+            "1.50",
+            "--provider",
+            "anthropic",
+            "--source",
+            "paste",
+            "--feature",
+            "042",
+            "--note",
+            note,
+        ],
+    )
+    assert result.exit_code == 0, f"snapshot failed: {result.output}"
+    files = list((tmp_path / ".specify" / "efficiency-snapshots").glob("*.md"))
+    assert len(files) == 1, f"expected one snapshot, got {files}"
+    return files[0]
+
+
+def test_cost_snapshot_windows_path_in_note_round_trips(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A Windows-style path in --note must serialize and parse back cleanly."""
+    windows_note = r"pasted from C:\Users\dev\Downloads\anthropic-usage.csv"
+    snapshot_path = _run_snapshot(tmp_path, monkeypatch, windows_note)
+    parsed = _parse_snapshot_frontmatter(snapshot_path.read_text(encoding="utf-8"))
+    assert parsed, f"frontmatter unparseable: {snapshot_path.read_text(encoding='utf-8')}"
+    assert parsed.get("note") == windows_note, (
+        f"note round-trip failed; sent {windows_note!r}, got {parsed.get('note')!r}"
+    )
+    assert parsed.get("amount_usd") == 1.5
+    assert parsed.get("provider") == "anthropic"
+
+
+def test_cost_snapshot_multiline_note_preserved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A multi-line --note must not collapse to a single line."""
+    multiline_note = "line one\nline two\nline three"
+    snapshot_path = _run_snapshot(tmp_path, monkeypatch, multiline_note)
+    body = snapshot_path.read_text(encoding="utf-8")
+    parsed = _parse_snapshot_frontmatter(body)
+    assert parsed.get("note") == multiline_note
+    # Prose rendering must keep the lines as separate lines (fenced code block)
+    assert "line one" in body and "line two" in body and "line three" in body
+    assert "line one line two line three" not in body
+
+
+# ---------------------------------------------------------------------------
+# cost snapshot: filename collision (regression: same-day+same-scope overwrote)
+# ---------------------------------------------------------------------------
+
+
+def test_two_snapshots_same_day_same_scope_do_not_overwrite(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Second snapshot on the same day for the same feature must not clobber the first."""
+    monkeypatch.chdir(tmp_path)
+    for run_idx in (1, 2):
+        result = runner.invoke(
+            app,
+            [
+                "cost",
+                "snapshot",
+                "--amount",
+                f"{run_idx}.50",
+                "--provider",
+                "anthropic",
+                "--feature",
+                "042",
+                "--note",
+                f"run {run_idx}",
+            ],
+        )
+        assert result.exit_code == 0, f"snapshot {run_idx} failed: {result.output}"
+    files = sorted((tmp_path / ".specify" / "efficiency-snapshots").glob("*.md"))
+    assert len(files) == 2, (
+        f"expected two distinct snapshot files, got {[f.name for f in files]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# _parse_snapshot_frontmatter: BOM tolerance (regression: silent empty parse)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_snapshot_frontmatter_tolerates_bom() -> None:
+    """A BOM-prefixed snapshot file must still parse correctly."""
+    body = "\ufeff---\nkind: efficiency-snapshot\nfeature: '042'\namount_usd: 1.5\n---\n\n# heading\n"
+    parsed = _parse_snapshot_frontmatter(body)
+    assert parsed, "BOM-prefixed frontmatter parsed as empty"
+    assert parsed.get("kind") == "efficiency-snapshot"
+    assert parsed.get("feature") == "042"
+    assert parsed.get("amount_usd") == 1.5
+
+
+def test_parse_snapshot_frontmatter_ignores_non_frontmatter() -> None:
+    """A body without a leading `---` returns {} (not a crash)."""
+    assert _parse_snapshot_frontmatter("just prose, no frontmatter") == {}
+
+
+def test_parse_snapshot_frontmatter_unclosed_delimiter_returns_empty() -> None:
+    """A `---` open without a matching close returns {} (not a crash)."""
+    assert _parse_snapshot_frontmatter("---\nkey: value\n") == {}
+
+
+# ---------------------------------------------------------------------------
+# efficiency report: feature filter must not collide on numeric suffix
+# ---------------------------------------------------------------------------
+
+
+def test_efficiency_report_feature_filter_does_not_collide(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--feature 42` must not match snapshots for feature `042` or `142`."""
+    monkeypatch.chdir(tmp_path)
+    for feature in ("42", "042", "142"):
+        result = runner.invoke(
+            app,
+            [
+                "cost",
+                "snapshot",
+                "--amount",
+                "1.00",
+                "--provider",
+                "anthropic",
+                "--feature",
+                feature,
+                "--note",
+                f"snap for {feature}",
+            ],
+        )
+        assert result.exit_code == 0
+    result = runner.invoke(
+        app, ["efficiency", "report", "--advisory", "--feature", "42"]
+    )
+    assert result.exit_code == 0
+    stdout = result.stdout
+    # Must show feature 42, NOT 042 or 142
+    assert "snap for 42" not in stdout  # note is not in the report; use feature scope
+    assert "feature 42" in stdout
+    # Anti-collision: 042 and 142 must NOT appear as scopes in this filtered view
+    assert "feature 042" not in stdout
+    assert "feature 142" not in stdout


### PR DESCRIPTION
## Summary

Introduces v0.4's **advisory model-tier routing**: consumer projects can pin a coordinator model (Haiku by default) for coordination-heavy turns, an implementer model (Sonnet) for code generation, and a HITL model (Opus) for `/atomicspec.plan` checkpoints. Shipped **advisor-off by default** — v0.3 upgrade paths see byte-for-byte identical behavior. Per-feature measurement primitive deliberately deferred to v0.4.1 on Claude Code's stable hook API (mirrors the v0.3.0 → v0.3.1 "surface first, enforcement second" pattern).

## What ships in v0.4.0

- New `registry.efficiency` block (schema 5→6): `model_tiers.{coordinator,implementer,hitl}` + `advisor_enabled: false` + `snapshot_recorded`.
- Three CLI subcommands: `atomicspec select-model --phase X`, `atomicspec cost snapshot`, `atomicspec efficiency report --advisory`.
- Phase 1 Prelude — Efficiency Hint block added to all four command templates (`specify.md`, `plan.md`, `tasks.md`, `implement.md`).
- Directives 7 + 8 amended in place (v0.2 precedent) — nine directives stays nine, no new Directive 10.
- Orientation-run files gain `## Efficiency` H2 (advisor state + registry pointer for v0.4.1 hook-based measurement to compare against).
- New user-facing doc at [`docs/efficiency.md`](../blob/feat/v0.4-efficiency/docs/efficiency.md).
- Site `upgrade.mdx` gains full "What Changed in v0.4.0" + "What Changed in v0.3.0" sections; `quickstart.mdx` PyPI note updated from stale "planned for v0.1.0".

## Deliberately deferred to v0.4.1

- `atomicspec baseline record --feature NNN` on Claude Code hooks (`Stop` / `PostToolUse` / `SessionEnd`) + Anthropic Console CSV import + Codex CLI JSONL adapter (separate flag).
- Flip `advisor_enabled: true` default behind promotion evidence bar.

## Deliberately scope-out for v0.4.x

Cursor / Windsurf / Copilot / Gemini CLI have no equivalent hook API and no path to token-level measurement in v0.4.x. The tier config still applies to them advisorily; they don't measure. Honest constraint.

## Reviewed adversarially before merge

Four parallel review panels (code correctness, doc completeness, governance consistency, DX walkthrough) ran against the first-draft implementation. Findings addressed in this branch:

**6 P0 code bugs fixed** (all covered by regression tests):
- `advisor_enabled: 'false'` (quoted string) silently flipped advisor ON — `bool("false") == True`. Fixed with strict `is True` check.
- Windows paths in `--note` corrupted snapshot files (`\U` treated as YAML unicode escape). Fixed with `yaml.safe_dump`.
- Multi-line `--note` collapsed to a single line. Fixed with fenced-block rendering.
- BOM-prefixed snapshot files silently ignored. Fixed with explicit `﻿` strip.
- Same-day + same-scope `cost snapshot` calls overwrote each other. Fixed with HHMMSS + microseconds in filename.
- `select-model --phase <typo>` silently returned empty. Fixed with Typer `Phase` enum.
- Report sorted snapshots alphabetically by filename. Fixed to sort by parsed `recorded_at`.
- Feature filter collided on `42` vs `042` vs `142`. Fixed to filter on parsed frontmatter field.

**6 P0 doc lies fixed**:
- Site `prime-directives.mdx` was still on "Eight Prime Directives" — Directive 9 body was never mirrored during v0.3 shipment. CHANGELOG v0.4.0's "in lockstep" claim was materially false; Directive 9 body now finally ported to site MDX.
- "Eight" → "Nine" swept across `memory/constitution.md:7`, `README.md:22` TL;DR, and 3 other site MDX files (`atomic-traceability-model.mdx`, `contributing.mdx`, `support.mdx`).
- `docs/efficiency.md` was self-contradictory on Codex adapter version (v0.4.1 vs v0.5). Reconciled to v0.4.1.
- `docs/efficiency.md` mixed `.specify/efficiency-baselines/` and `.specify/efficiency-snapshots/`. Clarified as two distinct directories with distinct purposes.
- Snapshot naming + retention + sort behavior documented.
- README Available Commands section: new `Efficiency Commands (v0.4+)` block with all three subcommands + link to `docs/efficiency.md`.
- README Status section: link to `docs/efficiency.md`.

**15 regression tests added** (28 tests total, all pass).

## Test plan

- [x] `pytest tests/` — 28/28 pass
- [x] `atomicspec select-model --phase X` (all three phases) — verified in scratch project with `advisor_enabled: true`; returns empty with `advisor_enabled: false`.
- [x] `atomicspec cost snapshot` writes valid YAML frontmatter — verified with Windows path, multi-line note, batched same-second calls.
- [x] `atomicspec efficiency report --advisory` prints tier table + snapshot table; sorts by `recorded_at`; filter matches exactly.
- [x] `cd site && npm run build` — 13 pages built, no MDX errors, Directive 9 body renders on `/docs/prime-directives`.
- [ ] Contract test (byte-for-byte v0.3 behavior with `advisor_enabled: false` on a fixture feature) — requires interactive agent session; recommend running before tagging v0.4.0.
- [ ] Fresh consumer project via `atomicspec init` — recommend running before tagging v0.4.0 (release pipeline builds template zips at tag time).

## Follow-ups after merge

- Tag `v0.4.0` on `main` to trigger the PyPI publish workflow (release.yml + publish.yml).
- Maintainer-run fixture study on 8–10 reference features between v0.4.0 and v0.4.1 to back the projected 28% savings claim honestly (Anthropic Advisor Strategy source).
- v0.4.1 scope: hook-based `baseline record`, CSV import, Codex JSONL adapter, evidence-gated flip of `advisor_enabled` default.