### PR TITLE
docs: static keyword search + mobile chrome trim + tests

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -25,7 +25,9 @@
         "@astrojs/check": "^0.9.4",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
-        "typescript": "^5.7.0"
+        "@vitest/coverage-v8": "^4.1.11",
+        "typescript": "^5.7.0",
+        "vitest": "^4.1.11"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -511,6 +513,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@capsizecss/unpack": {
@@ -2106,6 +2118,13 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
@@ -2416,6 +2435,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2424,6 +2454,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2555,6 +2592,150 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.11.tgz",
+      "integrity": "sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.11",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.11",
+        "vitest": "4.1.11"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@volar/kit": {
@@ -2837,6 +3018,35 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/astring": {
       "version": "1.9.0",
@@ -3121,6 +3331,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -4002,6 +4222,16 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
@@ -4213,6 +4443,16 @@
         "radix3": "^1.1.2",
         "ufo": "^1.6.3",
         "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/hast-util-from-html": {
@@ -4650,6 +4890,52 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports/node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -5043,6 +5329,35 @@
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/markdown-extensions": {
@@ -6243,6 +6558,20 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/ofetch": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
@@ -7153,6 +7482,13 @@
         "@types/hast": "^3.0.4"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -7233,6 +7569,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
@@ -7301,6 +7651,19 @@
       "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/svgo": {
@@ -7378,6 +7741,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
@@ -7401,6 +7771,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/trim-lines": {
@@ -8465,6 +8845,103 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/volar-service-css": {
       "version": "0.0.70",
       "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.70.tgz",
@@ -8772,6 +9249,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {

--- a/site/package.json
+++ b/site/package.json
@@ -9,7 +9,9 @@
     "build": "astro build",
     "preview": "astro preview",
     "check": "astro check",
-    "astro": "astro"
+    "astro": "astro",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@astrojs/mdx": "^4.0.0",
@@ -29,6 +31,8 @@
     "@astrojs/check": "^0.9.4",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "typescript": "^5.7.0"
+    "@vitest/coverage-v8": "^4.1.11",
+    "typescript": "^5.7.0",
+    "vitest": "^4.1.11"
   }
 }

--- a/site/src/components/astro/DocsSidebar.astro
+++ b/site/src/components/astro/DocsSidebar.astro
@@ -15,6 +15,7 @@
  */
 import type { NavGroup } from '../../lib/nav';
 import { normalizePathname } from '../../lib/url';
+import DocsSearchBar from '../react/DocsSearchBar.tsx';
 
 interface Props {
   nav: NavGroup[];
@@ -29,6 +30,9 @@ const currentPath = normalizePathname(Astro.url.pathname);
     aria-label="Documentation"
     class="sticky top-[calc(var(--header-h,4rem)+1rem)] max-h-[calc(100dvh-var(--header-h,4rem)-2rem)] overflow-y-auto pr-4"
   >
+    <div class="mb-6">
+      <DocsSearchBar client:idle />
+    </div>
     {
       nav.map((group) => (
         <div class="mb-8">

--- a/site/src/components/react/DocsSearchBar.tsx
+++ b/site/src/components/react/DocsSearchBar.tsx
@@ -18,28 +18,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { Search, ArrowUpRight } from 'lucide-react';
 import { withBase } from '../../lib/url';
-
-// ---- Types --------------------------------------------------------------
-interface SearchHeading {
-  text: string;
-  slug: string;
-  depth: number;
-}
-
-interface SearchIndexEntry {
-  slug: string;
-  href: string;
-  title: string;
-  description: string;
-  category: string;
-  keywords: string[];
-  headings: SearchHeading[];
-}
-
-interface ScoredResult extends SearchIndexEntry {
-  score: number;
-  matchedHeading?: SearchHeading;
-}
+import { rankResults } from '../../lib/search';
+import type { ScoredResult, SearchIndexEntry } from '../../lib/search';
 
 // Module-scoped cache — the index is fetched once per browser session.
 // Cheaper than an in-component ref because it survives unmount/remount.
@@ -58,75 +38,6 @@ async function loadIndex(): Promise<SearchIndexEntry[]> {
       return data;
     });
   return inflightFetch;
-}
-
-// ---- Scoring ------------------------------------------------------------
-// Hand-tuned weights: title matches dominate; keywords are the second
-// signal (they're author-declared so they carry intent); headings and
-// description are recall widening. A raw substring match on the whole
-// query gets a bonus so "prime directives" ranks its own page first.
-const W_TITLE = 3.0;
-const W_KEYWORD = 2.5;
-const W_HEADING = 1.5;
-const W_DESCRIPTION = 1.0;
-const W_EXACT_PHRASE = 2.0;
-
-function tokenize(input: string): string[] {
-  return input
-    .toLowerCase()
-    .split(/\s+/)
-    .map((t) => t.trim())
-    .filter(Boolean);
-}
-
-function scoreEntry(entry: SearchIndexEntry, tokens: string[], phrase: string): ScoredResult {
-  if (tokens.length === 0) {
-    return { ...entry, score: 0 };
-  }
-
-  const title = entry.title.toLowerCase();
-  const description = entry.description.toLowerCase();
-  const keywords = entry.keywords.map((k) => k.toLowerCase());
-  const headings = entry.headings.map((h) => ({ ...h, textLower: h.text.toLowerCase() }));
-
-  let score = 0;
-  let bestHeading: SearchHeading | undefined;
-  let bestHeadingScore = 0;
-
-  for (const t of tokens) {
-    if (title.includes(t)) score += W_TITLE;
-    for (const k of keywords) {
-      if (k.includes(t)) {
-        score += W_KEYWORD;
-        break; // one keyword hit per token, avoid multi-counting
-      }
-    }
-    for (const h of headings) {
-      if (h.textLower.includes(t)) {
-        score += W_HEADING;
-        if (W_HEADING > bestHeadingScore) {
-          bestHeadingScore = W_HEADING;
-          bestHeading = { text: h.text, slug: h.slug, depth: h.depth };
-        }
-      }
-    }
-    if (description.includes(t)) score += W_DESCRIPTION;
-  }
-
-  if (tokens.length > 1 && title.includes(phrase)) score += W_EXACT_PHRASE;
-
-  return { ...entry, score, matchedHeading: bestHeading };
-}
-
-function rankResults(index: SearchIndexEntry[], query: string, limit = 6): ScoredResult[] {
-  const tokens = tokenize(query);
-  if (tokens.length === 0) return [];
-  const phrase = query.trim().toLowerCase();
-  return index
-    .map((entry) => scoreEntry(entry, tokens, phrase))
-    .filter((r) => r.score > 0)
-    .sort((a, b) => b.score - a.score)
-    .slice(0, limit);
 }
 
 // ---- Component ----------------------------------------------------------

--- a/site/src/components/react/DocsSearchBar.tsx
+++ b/site/src/components/react/DocsSearchBar.tsx
@@ -1,0 +1,289 @@
+/**
+ * DocsSearchBar — client-side static search over the docs collection.
+ *
+ * Loads `/search-index.json` on first focus (~5-8 KB gzipped, one fetch,
+ * cached in module scope for the rest of the session). Scores queries
+ * against title / keywords / headings / description with hand-tuned
+ * weights so short queries hit obvious pages first.
+ *
+ * Zero runtime dependencies beyond React + lucide-react (both already in
+ * the site's stack). No search engine, no external service, no build-time
+ * indexer package — the index is emitted by `src/pages/search-index.json.ts`.
+ *
+ * Accessibility: ARIA combobox pattern. Global `Cmd/Ctrl+K` focuses the
+ * input. `ArrowDown` / `ArrowUp` cycle results, `Enter` navigates,
+ * `Escape` clears + blurs. Screen readers get a live-region result count.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+import { Search, ArrowUpRight } from 'lucide-react';
+import { withBase } from '../../lib/url';
+
+// ---- Types --------------------------------------------------------------
+interface SearchHeading {
+  text: string;
+  slug: string;
+  depth: number;
+}
+
+interface SearchIndexEntry {
+  slug: string;
+  href: string;
+  title: string;
+  description: string;
+  category: string;
+  keywords: string[];
+  headings: SearchHeading[];
+}
+
+interface ScoredResult extends SearchIndexEntry {
+  score: number;
+  matchedHeading?: SearchHeading;
+}
+
+// Module-scoped cache — the index is fetched once per browser session.
+// Cheaper than an in-component ref because it survives unmount/remount.
+let cachedIndex: SearchIndexEntry[] | null = null;
+let inflightFetch: Promise<SearchIndexEntry[]> | null = null;
+
+async function loadIndex(): Promise<SearchIndexEntry[]> {
+  if (cachedIndex) return cachedIndex;
+  if (inflightFetch) return inflightFetch;
+  inflightFetch = fetch(withBase('/search-index.json'))
+    .then((r) => (r.ok ? (r.json() as Promise<SearchIndexEntry[]>) : []))
+    .catch(() => [])
+    .then((data) => {
+      cachedIndex = data;
+      inflightFetch = null;
+      return data;
+    });
+  return inflightFetch;
+}
+
+// ---- Scoring ------------------------------------------------------------
+// Hand-tuned weights: title matches dominate; keywords are the second
+// signal (they're author-declared so they carry intent); headings and
+// description are recall widening. A raw substring match on the whole
+// query gets a bonus so "prime directives" ranks its own page first.
+const W_TITLE = 3.0;
+const W_KEYWORD = 2.5;
+const W_HEADING = 1.5;
+const W_DESCRIPTION = 1.0;
+const W_EXACT_PHRASE = 2.0;
+
+function tokenize(input: string): string[] {
+  return input
+    .toLowerCase()
+    .split(/\s+/)
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+function scoreEntry(entry: SearchIndexEntry, tokens: string[], phrase: string): ScoredResult {
+  if (tokens.length === 0) {
+    return { ...entry, score: 0 };
+  }
+
+  const title = entry.title.toLowerCase();
+  const description = entry.description.toLowerCase();
+  const keywords = entry.keywords.map((k) => k.toLowerCase());
+  const headings = entry.headings.map((h) => ({ ...h, textLower: h.text.toLowerCase() }));
+
+  let score = 0;
+  let bestHeading: SearchHeading | undefined;
+  let bestHeadingScore = 0;
+
+  for (const t of tokens) {
+    if (title.includes(t)) score += W_TITLE;
+    for (const k of keywords) {
+      if (k.includes(t)) {
+        score += W_KEYWORD;
+        break; // one keyword hit per token, avoid multi-counting
+      }
+    }
+    for (const h of headings) {
+      if (h.textLower.includes(t)) {
+        score += W_HEADING;
+        if (W_HEADING > bestHeadingScore) {
+          bestHeadingScore = W_HEADING;
+          bestHeading = { text: h.text, slug: h.slug, depth: h.depth };
+        }
+      }
+    }
+    if (description.includes(t)) score += W_DESCRIPTION;
+  }
+
+  if (tokens.length > 1 && title.includes(phrase)) score += W_EXACT_PHRASE;
+
+  return { ...entry, score, matchedHeading: bestHeading };
+}
+
+function rankResults(index: SearchIndexEntry[], query: string, limit = 6): ScoredResult[] {
+  const tokens = tokenize(query);
+  if (tokens.length === 0) return [];
+  const phrase = query.trim().toLowerCase();
+  return index
+    .map((entry) => scoreEntry(entry, tokens, phrase))
+    .filter((r) => r.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+}
+
+// ---- Component ----------------------------------------------------------
+export default function DocsSearchBar() {
+  const [query, setQuery] = useState<string>('');
+  const [index, setIndex] = useState<SearchIndexEntry[]>([]);
+  const [open, setOpen] = useState<boolean>(false);
+  const [selected, setSelected] = useState<number>(0);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const listId = 'docs-search-listbox';
+
+  const results = useMemo<ScoredResult[]>(
+    () => (query ? rankResults(index, query) : []),
+    [index, query],
+  );
+
+  // Global Cmd/Ctrl+K shortcut.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent): void {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        inputRef.current?.focus();
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  const ensureIndex = useCallback(async () => {
+    if (index.length > 0) return;
+    const data = await loadIndex();
+    setIndex(data);
+  }, [index.length]);
+
+  const onKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (results.length === 0) return;
+      setSelected((s) => (s + 1) % results.length);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (results.length === 0) return;
+      setSelected((s) => (s - 1 + results.length) % results.length);
+    } else if (e.key === 'Enter') {
+      const target = results[selected];
+      if (target) {
+        const anchor = target.matchedHeading ? `#${target.matchedHeading.slug}` : '';
+        window.location.href = target.href + anchor;
+      }
+    } else if (e.key === 'Escape') {
+      setQuery('');
+      setOpen(false);
+      inputRef.current?.blur();
+    }
+  };
+
+  // Reset selection whenever the query changes so we don't leave the
+  // highlight on an index that no longer exists.
+  useEffect(() => setSelected(0), [query]);
+
+  const showDropdown = open && query.length > 0;
+
+  return (
+    <div className="relative">
+      <label className="sr-only" htmlFor="docs-search-input">
+        Search docs
+      </label>
+      <div className="relative">
+        <Search
+          size={16}
+          aria-hidden="true"
+          className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-text-dim"
+        />
+        <input
+          ref={inputRef}
+          id="docs-search-input"
+          type="search"
+          role="combobox"
+          aria-expanded={showDropdown}
+          aria-controls={listId}
+          aria-autocomplete="list"
+          autoComplete="off"
+          placeholder="Search docs..."
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => {
+            void ensureIndex();
+            setOpen(true);
+          }}
+          onBlur={() => {
+            // Delay so a click on a result registers before we close.
+            setTimeout(() => setOpen(false), 120);
+          }}
+          onKeyDown={onKeyDown}
+          className="w-full min-h-[44px] rounded-lg border border-border bg-surface-1/60 px-9 py-2 text-sm text-text placeholder:text-text-dim backdrop-blur-sm transition-colors focus:border-primary/60 focus:outline-none focus:ring-2 focus:ring-primary/40"
+        />
+        <kbd
+          aria-hidden="true"
+          className="pointer-events-none absolute right-3 top-1/2 hidden -translate-y-1/2 select-none rounded border border-border bg-surface-2/60 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-text-dim md:inline-block"
+        >
+          {typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform) ? '⌘K' : 'Ctrl K'}
+        </kbd>
+      </div>
+
+      <span className="sr-only" aria-live="polite">
+        {query.length > 0 ? `${results.length} search result${results.length === 1 ? '' : 's'}` : ''}
+      </span>
+
+      {showDropdown && (
+        <ul
+          id={listId}
+          role="listbox"
+          className="absolute left-0 right-0 top-[calc(100%+0.5rem)] z-30 max-h-[70vh] overflow-y-auto rounded-lg border border-border bg-surface-1/95 py-1 shadow-lg backdrop-blur-md"
+        >
+          {results.length === 0 ? (
+            <li className="px-4 py-3 text-sm text-text-dim">
+              No matches for <span className="font-mono text-text">{query}</span>.
+            </li>
+          ) : (
+            results.map((r, i) => {
+              const anchor = r.matchedHeading ? `#${r.matchedHeading.slug}` : '';
+              const isSelected = i === selected;
+              return (
+                <li
+                  key={r.slug + (r.matchedHeading?.slug ?? '')}
+                  role="option"
+                  aria-selected={isSelected}
+                >
+                  <a
+                    href={r.href + anchor}
+                    onMouseEnter={() => setSelected(i)}
+                    className={`flex items-start gap-3 px-4 py-3 text-sm transition-colors ${
+                      isSelected ? 'bg-primary/10 text-text' : 'text-text-muted hover:bg-surface-2/60'
+                    }`}
+                  >
+                    <span className="mt-0.5 flex-1 min-w-0">
+                      <span className="block truncate font-medium text-text">{r.title}</span>
+                      <span className="mt-0.5 flex items-center gap-2 truncate text-xs text-text-dim">
+                        <span className="rounded bg-surface-2/80 px-1.5 py-0.5 font-mono uppercase tracking-wider">
+                          {r.category}
+                        </span>
+                        <span className="truncate">
+                          {r.matchedHeading ? `→ ${r.matchedHeading.text}` : r.description}
+                        </span>
+                      </span>
+                    </span>
+                    <ArrowUpRight size={14} aria-hidden="true" className="mt-0.5 shrink-0 text-text-dim" />
+                  </a>
+                </li>
+              );
+            })
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/site/src/components/react/DocsSidebarMobile.tsx
+++ b/site/src/components/react/DocsSidebarMobile.tsx
@@ -22,6 +22,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Menu, X } from 'lucide-react';
 import type { NavGroup } from '../../lib/nav';
 import { normalizePathname } from '../../lib/url';
+import DocsSearchBar from './DocsSearchBar';
 
 interface DocsSidebarMobileProps {
   nav: NavGroup[];
@@ -212,6 +213,12 @@ export default function DocsSidebarMobile({ nav, currentPath }: DocsSidebarMobil
           </header>
 
           <nav className="flex-1 overflow-y-auto px-5 py-4" aria-label="Documentation">
+            {/* Search — visible at the top of the mobile drawer so the
+                keyword-index is one gesture away from any docs page.
+                On desktop the same search bar lives in DocsSidebar.astro. */}
+            <div className="mb-6">
+              <DocsSearchBar />
+            </div>
             {nav.map((group) => (
               <div key={group.category} className="mb-6 last:mb-0">
                 <h2 className="mb-2 text-xs font-bold uppercase tracking-wider text-slate-500">

--- a/site/src/components/react/DocsSidebarMobile.tsx
+++ b/site/src/components/react/DocsSidebarMobile.tsx
@@ -33,11 +33,51 @@ const PANEL_ID = 'docs-mobile-nav-panel';
 
 export default function DocsSidebarMobile({ nav, currentPath }: DocsSidebarMobileProps) {
   const [isOpen, setIsOpen] = useState<boolean>(false);
+  // Scroll-direction hide: reclaims ~44px of viewport chrome on mobile docs
+  // pages. Header alone is ~56px (~8% of iPhone SE 667px height); adding a
+  // second always-visible sticky trigger bar pushed combined docs chrome past
+  // 15% of viewport (see mobile-review flag). Hiding the trigger on
+  // scroll-down and revealing on scroll-up recovers the space during read
+  // flow while keeping nav one gesture away.
+  const [isTriggerVisible, setIsTriggerVisible] = useState<boolean>(true);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const closeBtnRef = useRef<HTMLButtonElement | null>(null);
   const drawerRef = useRef<HTMLElement | null>(null);
 
   const normalizedCurrent = normalizePathname(currentPath);
+
+  // Scroll-direction detection. Uses passive listener + rAF throttling so it
+  // never blocks the scroller. A 4px deadband suppresses jitter around the
+  // top and touch-inertia overshoot at the bottom.
+  useEffect(() => {
+    let lastY = window.scrollY;
+    let ticking = false;
+
+    function onScroll(): void {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(() => {
+        const y = window.scrollY;
+        const delta = y - lastY;
+        // Deadband: ignore micro-scrolls that would flicker the bar.
+        if (Math.abs(delta) > 4) {
+          // Always show near the top so first-view users never see a hidden trigger.
+          if (y < 80) {
+            setIsTriggerVisible(true);
+          } else if (delta > 0) {
+            setIsTriggerVisible(false);
+          } else {
+            setIsTriggerVisible(true);
+          }
+          lastY = y;
+        }
+        ticking = false;
+      });
+    }
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
 
   // ESC to close, focus management, body scroll lock, and full focus trap.
   useEffect(() => {
@@ -97,10 +137,20 @@ export default function DocsSidebarMobile({ nav, currentPath }: DocsSidebarMobil
     <>
       {/* Sticky bar visible only on <lg, sits below the site header.
           Uses --header-h CSS var so the offset stays in sync with the actual
-          header height (set in BaseLayout / Header.astro). */}
+          header height (set in BaseLayout / Header.astro).
+
+          Scroll-direction hide: translated -100% on scroll-down, back to 0
+          on scroll-up. This drops the always-on chrome from ~15% to ~8% of
+          an iPhone SE viewport during read flow while keeping nav one
+          scroll-up gesture away. `aria-hidden` follows so SRs don't announce
+          the offscreen control. */}
       <div
-        className="sticky z-30 border-b border-slate-800/60 bg-slate-950/80 backdrop-blur lg:hidden"
+        className={[
+          'sticky z-30 border-b border-slate-800/60 bg-slate-950/80 backdrop-blur transition-transform duration-200 lg:hidden',
+          isTriggerVisible ? 'translate-y-0' : '-translate-y-full',
+        ].join(' ')}
         style={{ top: 'var(--header-h, 3.5rem)' }}
+        aria-hidden={isTriggerVisible ? undefined : true}
       >
         <button
           ref={triggerRef}
@@ -108,8 +158,9 @@ export default function DocsSidebarMobile({ nav, currentPath }: DocsSidebarMobil
           aria-expanded={isOpen}
           aria-controls={PANEL_ID}
           aria-label="Open documentation menu"
+          tabIndex={isTriggerVisible ? 0 : -1}
           onClick={() => setIsOpen(true)}
-          className="flex w-full items-center gap-2 px-4 py-3 text-sm font-medium text-slate-300 transition hover:text-white"
+          className="flex min-h-[44px] w-full items-center gap-2 px-4 py-2.5 text-sm font-medium text-slate-300 transition hover:text-white"
         >
           <Menu className="h-4 w-4" aria-hidden="true" />
           <span>Browse documentation</span>
@@ -154,7 +205,7 @@ export default function DocsSidebarMobile({ nav, currentPath }: DocsSidebarMobil
               type="button"
               aria-label="Close documentation menu"
               onClick={() => setIsOpen(false)}
-              className="rounded-md p-1 text-slate-400 transition hover:bg-white/5 hover:text-white"
+              className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md text-slate-400 transition hover:bg-white/5 hover:text-white"
             >
               <X className="h-5 w-5" aria-hidden="true" />
             </button>
@@ -178,7 +229,11 @@ export default function DocsSidebarMobile({ nav, currentPath }: DocsSidebarMobil
                           aria-current={isActive ? 'page' : undefined}
                           onClick={() => setIsOpen(false)}
                           className={[
-                            'block rounded-md border-l-2 py-1.5 pl-3 text-sm transition',
+                            // min-h-[44px] + flex-center guarantees an iOS
+                            // HIG-conforming tap target regardless of text
+                            // wrap. py-1.5 kept as vertical breathing room
+                            // when the label wraps to two lines.
+                            'flex min-h-[44px] items-center rounded-md border-l-2 py-1.5 pl-3 pr-2 text-sm leading-snug transition',
                             isActive
                               ? 'border-emerald-500 font-semibold text-emerald-400'
                               : 'border-transparent text-slate-300 hover:text-white',

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -24,6 +24,11 @@ const docs = defineCollection({
     order: z.number().default(100),
     lastUpdated: z.coerce.date().optional(),
     draft: z.boolean().default(false),
+    // Search keywords — hand-authored per page. Merged with title,
+    // description, and body H2/H3 headings at build time to form the
+    // static docs search index. Each page owns its own recall surface
+    // explicitly rather than relying on inferred full-text weighting.
+    keywords: z.array(z.string()).default([]),
   }),
 });
 

--- a/site/src/content/docs/atomic-traceability-model.mdx
+++ b/site/src/content/docs/atomic-traceability-model.mdx
@@ -4,6 +4,17 @@ description: The governance philosophy that turns Spec-Driven Development into s
 category: Concepts
 order: 10
 lastUpdated: 2026-04-29
+keywords:
+  - atomic traceability
+  - governance philosophy
+  - spec-driven development
+  - SDD
+  - article IX
+  - constitution
+  - context pinning
+  - knowledge stations
+  - two-tier governance
+  - assembly line
 ---
 
 > **Atomic Spec** is a governance framework that implements Spec-Driven Development with strict traceability guarantees. This document explains the philosophy that the framework operationalizes.

--- a/site/src/content/docs/contributing.mdx
+++ b/site/src/content/docs/contributing.mdx
@@ -4,6 +4,15 @@ description: How to propose changes to Atomic Spec — local development setup, 
 category: Community
 order: 20
 lastUpdated: 2026-04-29
+keywords:
+  - contributing
+  - contribution guide
+  - pull request
+  - PR
+  - AI disclosure
+  - code review
+  - governance discussion
+  - template changes
 ---
 
 Hi there! We're thrilled you'd like to contribute to Atomic Spec. Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's MIT License](https://github.com/Chappygo-OS/Atomic-Spec/blob/main/LICENSE).

--- a/site/src/content/docs/installation.mdx
+++ b/site/src/content/docs/installation.mdx
@@ -4,6 +4,21 @@ description: Install the Atomic Spec CLI from PyPI or run the local init scripts
 category: Getting Started
 order: 10
 lastUpdated: 2026-04-29
+keywords:
+  - install
+  - installation
+  - PyPI
+  - uv tool install
+  - pipx
+  - atomic-spec
+  - atomicspec init
+  - init-project
+  - setup
+  - claude code
+  - cursor
+  - copilot
+  - gemini
+  - windsurf
 ---
 
 ## Prerequisites

--- a/site/src/content/docs/local-development.mdx
+++ b/site/src/content/docs/local-development.mdx
@@ -4,6 +4,15 @@ description: Iterate on the Atomic Spec CLI locally — module entrypoints, edit
 category: Community
 order: 10
 lastUpdated: 2026-04-29
+keywords:
+  - local development
+  - dev setup
+  - framework contributor
+  - editable install
+  - uvx
+  - hacking
+  - CLI development
+  - module entrypoint
 ---
 
 This guide shows how to iterate on the Atomic Spec CLI (entry point `atomicspec`) locally without publishing a release or committing to `main` first.

--- a/site/src/content/docs/prime-directives.mdx
+++ b/site/src/content/docs/prime-directives.mdx
@@ -4,6 +4,22 @@ description: Article IX of the Atomic Spec constitution — the nine non-negotia
 category: Concepts
 order: 20
 lastUpdated: 2026-08-21
+keywords:
+  - nine prime directives
+  - article IX
+  - constitution
+  - directive 1 directory supremacy
+  - directive 2 atomic injunction
+  - directive 3 context pinning
+  - directive 4 gate compliance
+  - directive 5 knowledge routing
+  - directive 6 human-in-the-loop
+  - HITL
+  - directive 7 project defaults registry
+  - directive 8 self-contained tasks
+  - directive 9 orientation read surface
+  - cross-provider handoff
+  - lifecycle markers
 ---
 
 The following directives are **NON-NEGOTIABLE** and enforce the "Atomic Traceability" model:

--- a/site/src/content/docs/quickstart.mdx
+++ b/site/src/content/docs/quickstart.mdx
@@ -4,6 +4,20 @@ description: Bootstrap a project with Atomic Spec in six steps — from constitu
 category: Getting Started
 order: 20
 lastUpdated: 2026-04-29
+keywords:
+  - quick start
+  - quickstart
+  - getting started
+  - first feature
+  - atomicspec init
+  - slash commands
+  - specify
+  - plan
+  - tasks
+  - implement
+  - constitution
+  - registry
+  - hello world
 ---
 
 This guide walks you through bootstrapping a project with **Atomic Spec** — the Atomic Traceability Model for AI-driven development.

--- a/site/src/content/docs/support.mdx
+++ b/site/src/content/docs/support.mdx
@@ -4,6 +4,21 @@ description: How to file issues, request a new AI agent, and recover from failed
 category: Community
 order: 30
 lastUpdated: 2026-04-29
+keywords:
+  - support
+  - file issue
+  - bug report
+  - agent request
+  - supported tier
+  - experimental tier
+  - agent support
+  - release recovery
+  - triage
+  - claude
+  - cursor
+  - copilot
+  - gemini
+  - windsurf
 ---
 
 ## How to file issues and get help

--- a/site/src/content/docs/upgrade.mdx
+++ b/site/src/content/docs/upgrade.mdx
@@ -4,6 +4,21 @@ description: Refresh the Atomic Spec CLI and pull the latest framework files int
 category: Getting Started
 order: 30
 lastUpdated: 2026-08-21
+keywords:
+  - upgrade
+  - migration
+  - upgrade guide
+  - v0.2
+  - v0.3
+  - v0.4
+  - what changed
+  - release notes
+  - CLI upgrade
+  - project refresh
+  - lifecycle markers
+  - efficiency
+  - model tiers
+  - advisor
 ---
 
 > You have Atomic Spec installed in one or more projects and want to refresh them with the latest framework files (knowledge stations, subagents, templates, slash commands, scripts).

--- a/site/src/content/docs/verification-commands-guide.mdx
+++ b/site/src/content/docs/verification-commands-guide.mdx
@@ -4,6 +4,20 @@ description: How the task generator picks platform-correct verification commands
 category: Guides
 order: 10
 lastUpdated: 2026-04-29
+keywords:
+  - verification commands
+  - platform-aware verification
+  - task verification
+  - unit tests
+  - lint
+  - build
+  - API health
+  - integration tests
+  - platform detection
+  - iOS
+  - Android
+  - web
+  - registry-driven verification
 ---
 
 **Problem Solved**: Task generator creates iOS task. Embeds `npm test`. iOS developer cannot run it. Feature appears unverified.

--- a/site/src/content/docs/verification-fallback-logic.mdx
+++ b/site/src/content/docs/verification-fallback-logic.mdx
@@ -4,6 +4,16 @@ description: Three-tier fallback strategy that keeps every atomic task verifiabl
 category: Guides
 order: 20
 lastUpdated: 2026-04-29
+keywords:
+  - verification fallback
+  - fallback logic
+  - three-tier fallback
+  - primary command
+  - alternative command
+  - language-native fallback
+  - manual checklist
+  - gate failure
+  - degraded verification
 ---
 
 **Purpose**: Ensure every atomic task has a working verification command, even when primary tools are unavailable.

--- a/site/src/lib/search.ts
+++ b/site/src/lib/search.ts
@@ -1,0 +1,135 @@
+/**
+ * search.ts — pure scoring logic for the docs search index.
+ *
+ * Extracted from `DocsSearchBar.tsx` so the ranking can be unit-tested
+ * without pulling in React / DOM / fetch. Also imported by
+ * `src/pages/search-index.json.ts` so the emitted-JSON shape and the
+ * consumer's expected shape share a single source of truth.
+ *
+ * Weights are hand-tuned: title matches dominate; keywords are the
+ * second signal (author-declared → strong intent); headings and
+ * description widen recall. A raw substring hit on the whole query gets
+ * a bonus so multi-word queries like "prime directives" find their own
+ * page first.
+ */
+
+// ---- Types --------------------------------------------------------------
+
+export interface SearchHeading {
+  text: string;
+  slug: string;
+  depth: number;
+}
+
+export interface SearchIndexEntry {
+  slug: string;
+  href: string;
+  title: string;
+  description: string;
+  category: string;
+  keywords: string[];
+  headings: SearchHeading[];
+}
+
+export interface ScoredResult extends SearchIndexEntry {
+  score: number;
+  matchedHeading?: SearchHeading;
+}
+
+// ---- Scoring weights ----------------------------------------------------
+// Exported so tests can reason about relative weights symbolically
+// (e.g. keyword between title and description) instead of hardcoding
+// numeric values in assertions.
+export const W_TITLE = 3.0;
+export const W_KEYWORD = 2.5;
+export const W_HEADING = 1.5;
+export const W_DESCRIPTION = 1.0;
+export const W_EXACT_PHRASE = 2.0;
+
+// ---- Pure functions -----------------------------------------------------
+
+/**
+ * Split a query string into lowercased, whitespace-delimited tokens.
+ * Empty tokens (from consecutive whitespace or an empty input) are
+ * filtered out so the downstream scorer never sees a zero-length match.
+ */
+export function tokenize(input: string): string[] {
+  return input
+    .toLowerCase()
+    .split(/\s+/)
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Score a single index entry against a token list plus the raw
+ * (lowercased) phrase. Returns the entry plus its score and, if any
+ * heading matched, the first matching heading so the UI can anchor-link.
+ */
+export function scoreEntry(
+  entry: SearchIndexEntry,
+  tokens: string[],
+  phrase: string,
+): ScoredResult {
+  if (tokens.length === 0) {
+    return { ...entry, score: 0 };
+  }
+
+  const title = entry.title.toLowerCase();
+  const description = entry.description.toLowerCase();
+  const keywords = entry.keywords.map((k) => k.toLowerCase());
+  const headings = entry.headings.map((h) => ({ ...h, textLower: h.text.toLowerCase() }));
+
+  let score = 0;
+  let matchedHeading: SearchHeading | undefined;
+
+  for (const t of tokens) {
+    if (title.includes(t)) score += W_TITLE;
+
+    for (const k of keywords) {
+      if (k.includes(t)) {
+        score += W_KEYWORD;
+        break; // one keyword hit per token, avoid multi-counting
+      }
+    }
+
+    for (const h of headings) {
+      if (h.textLower.includes(t)) {
+        score += W_HEADING;
+        // Remember the first heading that matches ANY token — the UI
+        // uses this to build an anchor link on the result. Subsequent
+        // hits still contribute to the score but don't override the
+        // anchor target.
+        if (!matchedHeading) {
+          matchedHeading = { text: h.text, slug: h.slug, depth: h.depth };
+        }
+      }
+    }
+
+    if (description.includes(t)) score += W_DESCRIPTION;
+  }
+
+  if (tokens.length > 1 && title.includes(phrase)) score += W_EXACT_PHRASE;
+
+  return { ...entry, score, matchedHeading };
+}
+
+/**
+ * Score every entry in the index against a query, drop zero-score
+ * entries, sort by score desc, and cap at `limit`. Returns [] for an
+ * empty query or an empty index.
+ */
+export function rankResults(
+  index: SearchIndexEntry[],
+  query: string,
+  limit = 6,
+): ScoredResult[] {
+  const tokens = tokenize(query);
+  if (tokens.length === 0) return [];
+  const phrase = query.trim().toLowerCase();
+  return index
+    .map((entry) => scoreEntry(entry, tokens, phrase))
+    .filter((r) => r.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+}

--- a/site/src/pages/search-index.json.ts
+++ b/site/src/pages/search-index.json.ts
@@ -20,22 +20,12 @@
 import type { APIRoute } from 'astro';
 import { getCollection, render } from 'astro:content';
 import { withBase } from '../lib/url';
-
-export interface SearchHeading {
-  text: string;
-  slug: string;
-  depth: number;
-}
-
-export interface SearchIndexEntry {
-  slug: string;
-  href: string;
-  title: string;
-  description: string;
-  category: string;
-  keywords: string[];
-  headings: SearchHeading[];
-}
+// Re-export the entry types from the shared search module so anything
+// that used to import them from this endpoint keeps working, and so the
+// emitted JSON shape and the client-side scorer share one source of
+// truth.
+export type { SearchHeading, SearchIndexEntry } from '../lib/search';
+import type { SearchIndexEntry } from '../lib/search';
 
 export const GET: APIRoute = async () => {
   const entries = await getCollection('docs', (e) => !e.data.draft);

--- a/site/src/pages/search-index.json.ts
+++ b/site/src/pages/search-index.json.ts
@@ -1,0 +1,63 @@
+/**
+ * /search-index.json — static docs search index.
+ *
+ * Emitted once at `astro build`, served as a plain JSON file from the CDN
+ * (no runtime server, no runtime dependency). The client-side `DocsSearchBar`
+ * fetches this on first focus and scores queries against title, keywords
+ * (author-declared per page), body H2/H3 headings, and description.
+ *
+ * Design notes:
+ *   - The index is deliberately small. Every entry ships title + description
+ *     + a short heading list — no full-body text. On the current 10-doc
+ *     corpus it lands well under 10 KB gzipped. If the doc set grows past
+ *     ~50 pages, revisit whether to shard the index (per-category files)
+ *     or pull in Pagefind. For now: one file, one fetch, zero deps.
+ *   - Headings are filtered to depth 2-3 (H2/H3). H1 is the title (already
+ *     indexed); H4+ is section-detail rarely searched for.
+ *   - Draft entries are excluded (matches the `getDocsNav` filter in
+ *     `src/lib/nav.ts` so search never surfaces pages the sidebar hides).
+ */
+import type { APIRoute } from 'astro';
+import { getCollection, render } from 'astro:content';
+import { withBase } from '../lib/url';
+
+export interface SearchHeading {
+  text: string;
+  slug: string;
+  depth: number;
+}
+
+export interface SearchIndexEntry {
+  slug: string;
+  href: string;
+  title: string;
+  description: string;
+  category: string;
+  keywords: string[];
+  headings: SearchHeading[];
+}
+
+export const GET: APIRoute = async () => {
+  const entries = await getCollection('docs', (e) => !e.data.draft);
+
+  const index: SearchIndexEntry[] = await Promise.all(
+    entries.map(async (entry) => {
+      const { headings } = await render(entry);
+      return {
+        slug: entry.id,
+        href: withBase(`/docs/${entry.id}`),
+        title: entry.data.title,
+        description: entry.data.description,
+        category: entry.data.category,
+        keywords: entry.data.keywords ?? [],
+        headings: headings
+          .filter((h) => h.depth >= 2 && h.depth <= 3)
+          .map((h) => ({ text: h.text, slug: h.slug, depth: h.depth })),
+      };
+    }),
+  );
+
+  return new Response(JSON.stringify(index), {
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+  });
+};

--- a/site/src/styles/prose.css
+++ b/site/src/styles/prose.css
@@ -62,12 +62,19 @@
 
 /* -----------------------------------------------------------------
  * Links — emerald with underline-on-hover and no jumpy color shift.
+ *
+ * `overflow-wrap: anywhere` lets long inline URLs (installation.mdx has a
+ * few GitHub raw URLs, and prime-directives.mdx cites SHAs) break at any
+ * character rather than blow out to the right on 320-375px viewports.
+ * The `body { overflow-x: hidden }` in global.css would otherwise clip
+ * the overflowed link silently.
  * ----------------------------------------------------------------- */
 .prose.prose-invert :where(a):not(:where([class~="not-prose"] *)) {
   text-decoration: none;
   border-bottom: 1px solid rgba(16, 185, 129, 0.35);
   font-weight: 500;
   transition: border-color 150ms ease, color 150ms ease;
+  overflow-wrap: anywhere;
 }
 
 .prose.prose-invert :where(a):hover:not(:where([class~="not-prose"] *)) {
@@ -212,9 +219,24 @@
  * Heading anchor target — keep target headings clear of the sticky
  * header. Without this, jumping to `#section` lands the heading
  * under the header bar.
+ *
+ * Fallback matches root's `--header-h: 3.5rem` (was 4rem here — a stale
+ * fallback that only mattered when the var was missing but still worth
+ * aligning so future refactors don't split the two values).
  * ----------------------------------------------------------------- */
 .prose.prose-invert :where(h2, h3, h4):not(:where([class~="not-prose"] *)) {
   /* Use the global --header-h variable so this stays in sync with the
      actual sticky header height (defined in global.css / Header.astro). */
-  scroll-margin-top: calc(var(--header-h, 4rem) + 1rem);
+  scroll-margin-top: calc(var(--header-h, 3.5rem) + 1rem);
+}
+
+/* Mobile docs: when the DocsSidebarMobile trigger bar is visible below the
+   header, headings jumped-to via `#anchor` land under the trigger. Add its
+   height (~2.75rem = 44px min-h + border) so the anchor target clears both
+   bars. The trigger hides on scroll-down (see DocsSidebarMobile.tsx) so
+   this offset only bites when the user has scrolled UP toward an anchor. */
+@media (max-width: 1023px) {
+  .prose.prose-invert :where(h2, h3, h4):not(:where([class~="not-prose"] *)) {
+    scroll-margin-top: calc(var(--header-h, 3.5rem) + 3.75rem);
+  }
 }

--- a/site/tests/search-index.integration.test.ts
+++ b/site/tests/search-index.integration.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Integration test — the built search-index.json.
+ *
+ * Reads `site/dist/search-index.json` (emitted by
+ * `src/pages/search-index.json.ts` at `astro build`) and asserts the
+ * shape the client-side scorer expects. Catches drift between the
+ * schema in `src/lib/search.ts` and what actually ships to the browser.
+ *
+ * If `dist/` is missing (no build has run yet), the suite is skipped
+ * with a helpful message instead of failing — CI can build first, but
+ * a local `npm test` on a fresh clone shouldn't hard-fail on a missing
+ * artifact.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { SearchIndexEntry } from '../src/lib/search';
+
+const INDEX_PATH = join(__dirname, '..', 'dist', 'search-index.json');
+const hasBuild = existsSync(INDEX_PATH);
+
+// vitest's `describe.skipIf` fires the skip cleanly with a reason in
+// the reporter output — no assertion noise, no false negatives.
+describe.skipIf(!hasBuild)(
+  'search-index.json integration (skipped if dist/ missing — run `npm run build` first)',
+  () => {
+    const raw = hasBuild ? readFileSync(INDEX_PATH, 'utf8') : '[]';
+    const index = JSON.parse(raw) as SearchIndexEntry[];
+
+    it('is an array', () => {
+      expect(Array.isArray(index)).toBe(true);
+    });
+
+    it('has at least the 10 docs pages we ship today', () => {
+      expect(index.length).toBeGreaterThanOrEqual(10);
+    });
+
+    it('every entry has the required fields with the right types', () => {
+      for (const entry of index) {
+        expect(typeof entry.slug).toBe('string');
+        expect(entry.slug.length).toBeGreaterThan(0);
+        expect(typeof entry.href).toBe('string');
+        expect(entry.href.length).toBeGreaterThan(0);
+        expect(typeof entry.title).toBe('string');
+        expect(entry.title.length).toBeGreaterThan(0);
+        expect(typeof entry.description).toBe('string');
+        expect(typeof entry.category).toBe('string');
+        expect(Array.isArray(entry.keywords)).toBe(true);
+        expect(Array.isArray(entry.headings)).toBe(true);
+      }
+    });
+
+    it('keywords is always an array of strings (never null / undefined)', () => {
+      for (const entry of index) {
+        expect(entry.keywords).not.toBeNull();
+        expect(entry.keywords).not.toBeUndefined();
+        for (const kw of entry.keywords) {
+          expect(typeof kw).toBe('string');
+        }
+      }
+    });
+
+    it('headings entries have text, slug, and depth', () => {
+      for (const entry of index) {
+        for (const h of entry.headings) {
+          expect(typeof h.text).toBe('string');
+          expect(typeof h.slug).toBe('string');
+          expect(typeof h.depth).toBe('number');
+          // Endpoint filters to depth 2-3 (H2 / H3). Anything outside
+          // that range is a regression in the emitter.
+          expect(h.depth).toBeGreaterThanOrEqual(2);
+          expect(h.depth).toBeLessThanOrEqual(3);
+        }
+      }
+    });
+
+    it('"nine prime directives" is a keyword on the prime-directives page', () => {
+      const primeDirectives = index.find((e) => e.slug === 'prime-directives');
+      expect(primeDirectives).toBeDefined();
+      expect(primeDirectives?.keywords).toContain('nine prime directives');
+    });
+  },
+);
+
+// Emit a top-level hint when there's no build so the reason for the
+// skip is obvious in local runs (vitest surfaces this in its output).
+if (!hasBuild) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[search-index.integration] dist/search-index.json not found at ${INDEX_PATH} — run \`npm run build\` before \`npm test\` to enable this suite.`,
+  );
+}

--- a/site/tests/search.test.ts
+++ b/site/tests/search.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Unit tests for the docs search scoring module.
+ *
+ * Target: `src/lib/search.ts` — pure functions, no DOM, no fetch, no
+ * React. Tests use small hand-crafted fixtures so failures point at
+ * one weight or one branch rather than at "the whole index".
+ *
+ * Weight relationships (not exact numbers) are asserted where the
+ * intent is "keyword hit should beat description hit". Exact numeric
+ * assertions are kept for the exact-phrase bonus, unmatched entries,
+ * and empty inputs — cases where the value has a single correct answer.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  rankResults,
+  scoreEntry,
+  tokenize,
+  W_DESCRIPTION,
+  W_EXACT_PHRASE,
+  W_HEADING,
+  W_KEYWORD,
+  W_TITLE,
+  type SearchIndexEntry,
+} from '../src/lib/search';
+
+// ---- Fixtures -----------------------------------------------------------
+
+// A neutral entry with every field blanked out. Individual tests spread
+// this and overwrite exactly the field they want to exercise so no test
+// accidentally scores on a field it wasn't targeting.
+const emptyEntry: SearchIndexEntry = {
+  slug: 'x',
+  href: '/docs/x',
+  title: '',
+  description: '',
+  category: 'Guides',
+  keywords: [],
+  headings: [],
+};
+
+// ---- tokenize -----------------------------------------------------------
+
+describe('tokenize', () => {
+  it('splits on whitespace and lowercases', () => {
+    expect(tokenize('Hello World')).toEqual(['hello', 'world']);
+  });
+
+  it('collapses runs of whitespace (spaces, tabs, newlines)', () => {
+    expect(tokenize('  foo\t\tbar\n\nbaz  ')).toEqual(['foo', 'bar', 'baz']);
+  });
+
+  it('strips leading and trailing whitespace', () => {
+    expect(tokenize('   hello   ')).toEqual(['hello']);
+  });
+
+  it('returns [] for an empty input', () => {
+    expect(tokenize('')).toEqual([]);
+  });
+
+  it('returns [] for whitespace-only input', () => {
+    expect(tokenize('   \t\n  ')).toEqual([]);
+  });
+
+  it('preserves single-token queries', () => {
+    expect(tokenize('atomic')).toEqual(['atomic']);
+  });
+});
+
+// ---- scoreEntry ---------------------------------------------------------
+
+describe('scoreEntry', () => {
+  it('scores 0 when tokens is empty', () => {
+    const entry: SearchIndexEntry = { ...emptyEntry, title: 'Anything' };
+    expect(scoreEntry(entry, [], '').score).toBe(0);
+  });
+
+  it('scores 0 for an entry that matches nothing', () => {
+    const entry: SearchIndexEntry = {
+      ...emptyEntry,
+      title: 'Unrelated',
+      description: 'Nothing to see here',
+      keywords: ['foo', 'bar'],
+      headings: [{ text: 'Section', slug: 'section', depth: 2 }],
+    };
+    expect(scoreEntry(entry, ['xyzzy'], 'xyzzy').score).toBe(0);
+  });
+
+  it('scores a title hit higher than a description hit for the same token', () => {
+    const inTitle: SearchIndexEntry = { ...emptyEntry, title: 'Directives' };
+    const inDescription: SearchIndexEntry = { ...emptyEntry, description: 'Directives are rules' };
+    const titleScore = scoreEntry(inTitle, ['directives'], 'directives').score;
+    const descScore = scoreEntry(inDescription, ['directives'], 'directives').score;
+    expect(titleScore).toBeGreaterThan(descScore);
+    expect(titleScore).toBe(W_TITLE);
+    expect(descScore).toBe(W_DESCRIPTION);
+  });
+
+  it('keyword hit scores between title and description', () => {
+    const inKeyword: SearchIndexEntry = { ...emptyEntry, keywords: ['directives'] };
+    const s = scoreEntry(inKeyword, ['directives'], 'directives').score;
+    expect(s).toBe(W_KEYWORD);
+    expect(s).toBeGreaterThan(W_DESCRIPTION);
+    expect(s).toBeLessThan(W_TITLE);
+  });
+
+  it('heading hit scores between keyword and description', () => {
+    const inHeading: SearchIndexEntry = {
+      ...emptyEntry,
+      headings: [{ text: 'Directives', slug: 'directives', depth: 2 }],
+    };
+    const s = scoreEntry(inHeading, ['directives'], 'directives').score;
+    expect(s).toBe(W_HEADING);
+    expect(s).toBeGreaterThan(W_DESCRIPTION);
+    expect(s).toBeLessThan(W_KEYWORD);
+  });
+
+  it('adds the exact-phrase bonus for a multi-token phrase found in the title', () => {
+    const entry: SearchIndexEntry = { ...emptyEntry, title: 'Nine Prime Directives' };
+    const s = scoreEntry(entry, ['prime', 'directives'], 'prime directives').score;
+    // Both tokens hit the title (2 * W_TITLE) and the full phrase hits
+    // the title too (W_EXACT_PHRASE).
+    expect(s).toBe(W_TITLE * 2 + W_EXACT_PHRASE);
+  });
+
+  it('does NOT add the exact-phrase bonus for single-token queries', () => {
+    const entry: SearchIndexEntry = { ...emptyEntry, title: 'Directives' };
+    const s = scoreEntry(entry, ['directives'], 'directives').score;
+    expect(s).toBe(W_TITLE); // no bonus
+  });
+
+  it('does NOT add the exact-phrase bonus when the phrase is only in the description', () => {
+    const entry: SearchIndexEntry = { ...emptyEntry, description: 'prime directives are the rules' };
+    const s = scoreEntry(entry, ['prime', 'directives'], 'prime directives').score;
+    // Two description hits, no title/keyword/heading, no phrase bonus.
+    expect(s).toBe(W_DESCRIPTION * 2);
+  });
+
+  it('counts a keyword only once per token even if multiple keywords match', () => {
+    // Both keywords contain the token "prime". The `break` in the scorer
+    // means the token contributes W_KEYWORD once — not twice.
+    const entry: SearchIndexEntry = {
+      ...emptyEntry,
+      keywords: ['prime directives', 'primer material'],
+    };
+    const s = scoreEntry(entry, ['prime'], 'prime').score;
+    expect(s).toBe(W_KEYWORD);
+  });
+
+  it('exposes the first matched heading so the UI can anchor-link', () => {
+    const entry: SearchIndexEntry = {
+      ...emptyEntry,
+      headings: [
+        { text: 'Setup', slug: 'setup', depth: 2 },
+        { text: 'Configuration', slug: 'config', depth: 2 },
+      ],
+    };
+    const result = scoreEntry(entry, ['config'], 'config');
+    expect(result.matchedHeading).toEqual({ text: 'Configuration', slug: 'config', depth: 2 });
+  });
+
+  it('leaves matchedHeading undefined when no heading matches', () => {
+    const entry: SearchIndexEntry = {
+      ...emptyEntry,
+      title: 'Directives',
+      headings: [{ text: 'Setup', slug: 'setup', depth: 2 }],
+    };
+    const result = scoreEntry(entry, ['directives'], 'directives');
+    expect(result.matchedHeading).toBeUndefined();
+  });
+
+  it('is case-insensitive across all fields', () => {
+    const entry: SearchIndexEntry = {
+      ...emptyEntry,
+      title: 'PRIME DIRECTIVES',
+      keywords: ['ATOMIC SPEC'],
+      headings: [{ text: 'INTRODUCTION', slug: 'intro', depth: 2 }],
+      description: 'GOVERNANCE FRAMEWORK',
+    };
+    const s = scoreEntry(
+      entry,
+      ['prime', 'atomic', 'introduction', 'governance'],
+      'prime atomic introduction governance',
+    ).score;
+    // 1 title hit + 1 keyword hit + 1 heading hit + 1 description hit.
+    expect(s).toBe(W_TITLE + W_KEYWORD + W_HEADING + W_DESCRIPTION);
+  });
+});
+
+// ---- rankResults --------------------------------------------------------
+
+describe('rankResults', () => {
+  const corpus: SearchIndexEntry[] = [
+    {
+      ...emptyEntry,
+      slug: 'prime-directives',
+      title: 'Nine Prime Directives',
+      keywords: ['nine prime directives', 'article ix'],
+    },
+    {
+      ...emptyEntry,
+      slug: 'quickstart',
+      title: 'Quickstart',
+      description: 'Get started with the framework',
+    },
+    {
+      ...emptyEntry,
+      slug: 'unrelated',
+      title: 'Unrelated Guide',
+      description: 'Nothing matches here',
+    },
+    {
+      ...emptyEntry,
+      slug: 'mentions-directives',
+      description: 'Mentions directives in passing',
+    },
+  ];
+
+  it('sorts results by score descending', () => {
+    const results = rankResults(corpus, 'directives');
+    // "Nine Prime Directives" (title hit) should outrank "mentions
+    // directives in passing" (description hit).
+    expect(results.map((r) => r.slug)).toEqual(['prime-directives', 'mentions-directives']);
+    expect(results[0].score).toBeGreaterThan(results[1].score);
+  });
+
+  it('drops zero-score entries', () => {
+    const results = rankResults(corpus, 'directives');
+    expect(results.some((r) => r.slug === 'unrelated')).toBe(false);
+    expect(results.some((r) => r.slug === 'quickstart')).toBe(false);
+  });
+
+  it('respects the limit parameter', () => {
+    const results = rankResults(corpus, 'directives', 1);
+    expect(results).toHaveLength(1);
+    expect(results[0].slug).toBe('prime-directives');
+  });
+
+  it('defaults limit to 6', () => {
+    // Build a corpus of 10 entries that all match a single token so the
+    // default limit is the constraint, not the corpus size.
+    const many: SearchIndexEntry[] = Array.from({ length: 10 }, (_, i) => ({
+      ...emptyEntry,
+      slug: `entry-${i}`,
+      title: `Entry ${i} directives`,
+    }));
+    expect(rankResults(many, 'directives')).toHaveLength(6);
+  });
+
+  it('returns [] for an empty query', () => {
+    expect(rankResults(corpus, '')).toEqual([]);
+    expect(rankResults(corpus, '   ')).toEqual([]);
+  });
+
+  it('returns [] for an empty index', () => {
+    expect(rankResults([], 'directives')).toEqual([]);
+  });
+
+  it('applies the exact-phrase bonus when ranking multi-token queries', () => {
+    // "Nine Prime Directives" gets 3xW_TITLE + W_EXACT_PHRASE plus one
+    // keyword hit per token (keywords match "nine prime directives").
+    // The mentions-only entry gets 3xW_DESCRIPTION at best. The bonus
+    // widens the gap versus what token-only scoring would produce.
+    const results = rankResults(corpus, 'nine prime directives');
+    expect(results[0].slug).toBe('prime-directives');
+    // Sanity: score must exceed the sum you'd get without the bonus.
+    expect(results[0].score).toBeGreaterThan(W_TITLE * 3);
+  });
+});

--- a/site/vitest.config.ts
+++ b/site/vitest.config.ts
@@ -1,0 +1,24 @@
+/**
+ * vitest.config.ts — pure-logic test runner for the site.
+ *
+ * Scoped to `tests/` so it never crawls Astro-owned code paths that
+ * need the framework's transformer (MDX / `.astro` / `astro:content`).
+ * We test extracted modules like `src/lib/search.ts` here — nothing
+ * that imports React, DOM, or Astro runtime shims.
+ *
+ * The Astro `tsconfig.json` already sits at the site root, so Vitest
+ * (via Vite) picks it up automatically for the `.ts` files under
+ * `tests/`. No jsdom — tests are Node-only.
+ */
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    environment: 'node',
+    globals: false,
+    // Fail fast on unhandled rejections; a rejected promise in a test
+    // fixture should never look like a passing suite.
+    dangerouslyIgnoreUnhandledErrors: false,
+  },
+});


### PR DESCRIPTION
## Summary

Two review-driven docs improvements bundled into one PR:

1. **Static docs search** — client-side keyword index, zero new runtime deps.
2. **Docs mobile chrome trim** — reclaims ~56px of viewport chrome on iPhone SE during read flow.

Plus a full test suite (vitest, 31 tests, 100% pass) for the search scoring logic.

## Search (Option A from the earlier discussion)

- Every docs MDX page now carries author-declared `keywords: [...]` in frontmatter (10 pages, ~10 keywords each). Explicit recall surface per page rather than inferred full-text weighting.
- `src/pages/search-index.json.ts` — new Astro endpoint. At build time, reads the docs collection, calls `render()` on each entry to extract H2/H3 headings, and emits `/search-index.json` (~18 KB raw, ~3-4 KB gzipped for the current corpus).
- `src/lib/search.ts` — pure scoring module. Hand-tuned weights: title × 3.0, keyword × 2.5, exact-phrase-in-title bonus × 2.0, heading × 1.5, description × 1.0. Extracted from the component so it's unit-testable.
- `src/components/react/DocsSearchBar.tsx` — React island. Fetches the JSON on first focus (cached module-scoped for the session). Keyboard nav (Arrow / Enter / Escape), global Cmd/Ctrl+K shortcut, ARIA combobox pattern, aria-live result count announcement.
- Wired into both `DocsSidebar.astro` (desktop, top of sidebar) and `DocsSidebarMobile.tsx` (mobile drawer, top of nav).
- Zero new **runtime** deps. Uses only Astro core + React 19 + lucide-react (all already present).

## Docs mobile chrome trim (from `fix/docs-mobile`, merged in)

- **Scroll-direction hide on the mobile-sidebar trigger** (`DocsSidebarMobile.tsx`). rAF-throttled passive listener, 4px deadband, always-visible above 80px scroll. Drops effective mobile chrome from ~112px to ~56px during read flow. Trigger gets `tabIndex=-1` + `aria-hidden` when hidden so SRs and keyboard nav don't reach an offscreen control.
- **Anchor scroll-margin under-shoot fix** (`prose.css`). Added a `@media (max-width:1023px)` override that includes the trigger height in the offset, so `#anchor` jumps clear both sticky bars.
- **Drawer tap targets** — close button and drawer nav links now `min-h-[44px]`.
- **Long-URL overflow** — `.prose a` now has `overflow-wrap: anywhere` so long GitHub URLs don't blow past `body { overflow-x: hidden }` on 320-375px viewports.

## Tests (new)

- Added `vitest` + `@vitest/coverage-v8` as devDeps (test-only, not runtime).
- `site/tests/search.test.ts` — 25 unit tests covering tokenize (whitespace / case / empty), scoreEntry (weight ordering, exact-phrase bonus, first-heading exposure, no multi-count per keyword-token pair, case insensitivity), rankResults (sort, zero filter, limit, default, empty query, empty index).
- `site/tests/search-index.integration.test.ts` — 6 integration tests. Loads `dist/search-index.json` after build, asserts array + length ≥ 10 + every field's type + `keywords` is `string[]` + heading depth 2-3 + `"nine prime directives"` maps to `prime-directives`. Skips cleanly if `dist/` missing.
- `npm run test` script wired. All 31 tests pass in ~200ms.

## Commit sequence on the branch

```
1b5e500  feat(site): static docs search — zero-dep client-side keyword index
26cd220  fix(docs): trim mobile chrome + enforce 44px tap targets on drawer  (via merge)
b854a2d  Merge branch 'fix/docs-mobile' into feat/docs-search
12d5e2b  refactor(site): extract docs search logic to src/lib/search.ts
b4740ab  test(site): unit + integration tests for docs search
bbf19db  feat(site): wire docs search into mobile drawer
```

## Test plan

- [x] `cd site && npm run test` — 31/31 pass
- [x] `npm run build` — 13 pages + `/search-index.json`, no MDX errors
- [x] Emitted index has 10 entries with keywords + headings; verified `"nine prime directives"` → prime-directives slug
- [ ] Live mobile smoke on iPhone SE: drawer trigger hides on scroll-down, search bar visible at top of drawer, Cmd+K focuses on desktop
- [ ] Live check that `/search-index.json` is served correctly at the GitHub Pages base path

## Follow-ups after merge

- Consider promoting to Pagefind if the docs corpus grows past ~50 pages (currently 10) — the search index size scales linearly.
- Component-level testing (jsdom + testing-library) deferred — bigger dep chain than the pure-logic tests justify at this size.