### PR TITLE
docs: hero search bar on /docs landing

### DIFF
--- a/site/src/components/react/DocsSearchBar.tsx
+++ b/site/src/components/react/DocsSearchBar.tsx
@@ -41,13 +41,27 @@ async function loadIndex(): Promise<SearchIndexEntry[]> {
 }
 
 // ---- Component ----------------------------------------------------------
-export default function DocsSearchBar() {
+
+interface DocsSearchBarProps {
+  /**
+   * `sidebar` (default) — compact styling for the docs sidebar / mobile drawer.
+   * `hero`             — larger padding + text for landing-page placement
+   *                       (docs/index) where the search is the primary action.
+   *
+   * Both variants share behavior, keyboard nav, and accessibility surface.
+   * Only visual weight differs.
+   */
+  variant?: 'sidebar' | 'hero';
+}
+
+export default function DocsSearchBar({ variant = 'sidebar' }: DocsSearchBarProps = {}) {
   const [query, setQuery] = useState<string>('');
   const [index, setIndex] = useState<SearchIndexEntry[]>([]);
   const [open, setOpen] = useState<boolean>(false);
   const [selected, setSelected] = useState<number>(0);
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const listId = 'docs-search-listbox';
+  const listId = variant === 'hero' ? 'docs-search-listbox-hero' : 'docs-search-listbox';
+  const isHero = variant === 'hero';
 
   const results = useMemo<ScoredResult[]>(
     () => (query ? rankResults(index, query) : []),
@@ -107,20 +121,22 @@ export default function DocsSearchBar() {
       </label>
       <div className="relative">
         <Search
-          size={16}
+          size={isHero ? 20 : 16}
           aria-hidden="true"
-          className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-text-dim"
+          className={`pointer-events-none absolute top-1/2 -translate-y-1/2 text-text-dim ${
+            isHero ? 'left-5' : 'left-3'
+          }`}
         />
         <input
           ref={inputRef}
-          id="docs-search-input"
+          id={isHero ? 'docs-search-input-hero' : 'docs-search-input'}
           type="search"
           role="combobox"
           aria-expanded={showDropdown}
           aria-controls={listId}
           aria-autocomplete="list"
           autoComplete="off"
-          placeholder="Search docs..."
+          placeholder={isHero ? 'Search the docs — nine directives, install, upgrade, verification…' : 'Search docs...'}
           value={query}
           onChange={(e) => {
             setQuery(e.target.value);
@@ -135,11 +151,17 @@ export default function DocsSearchBar() {
             setTimeout(() => setOpen(false), 120);
           }}
           onKeyDown={onKeyDown}
-          className="w-full min-h-[44px] rounded-lg border border-border bg-surface-1/60 px-9 py-2 text-sm text-text placeholder:text-text-dim backdrop-blur-sm transition-colors focus:border-primary/60 focus:outline-none focus:ring-2 focus:ring-primary/40"
+          className={
+            isHero
+              ? 'w-full min-h-[56px] rounded-xl border border-border bg-surface-1/70 px-14 py-3 text-base text-text placeholder:text-text-dim placeholder:truncate backdrop-blur-md transition-colors focus:border-primary/60 focus:outline-none focus:ring-2 focus:ring-primary/40 sm:text-lg'
+              : 'w-full min-h-[44px] rounded-lg border border-border bg-surface-1/60 px-9 py-2 text-sm text-text placeholder:text-text-dim backdrop-blur-sm transition-colors focus:border-primary/60 focus:outline-none focus:ring-2 focus:ring-primary/40'
+          }
         />
         <kbd
           aria-hidden="true"
-          className="pointer-events-none absolute right-3 top-1/2 hidden -translate-y-1/2 select-none rounded border border-border bg-surface-2/60 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-text-dim md:inline-block"
+          className={`pointer-events-none absolute top-1/2 hidden -translate-y-1/2 select-none rounded border border-border bg-surface-2/60 font-mono uppercase tracking-wider text-text-dim md:inline-block ${
+            isHero ? 'right-5 px-2 py-1 text-xs' : 'right-3 px-1.5 py-0.5 text-[10px]'
+          }`}
         >
           {typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform) ? '⌘K' : 'Ctrl K'}
         </kbd>
@@ -153,7 +175,11 @@ export default function DocsSearchBar() {
         <ul
           id={listId}
           role="listbox"
-          className="absolute left-0 right-0 top-[calc(100%+0.5rem)] z-30 max-h-[70vh] overflow-y-auto rounded-lg border border-border bg-surface-1/95 py-1 shadow-lg backdrop-blur-md"
+          className={`absolute left-0 right-0 z-30 max-h-[70vh] overflow-y-auto border border-border bg-surface-1/95 py-1 shadow-lg backdrop-blur-md ${
+            isHero
+              ? 'top-[calc(100%+0.75rem)] rounded-xl shadow-2xl'
+              : 'top-[calc(100%+0.5rem)] rounded-lg'
+          }`}
         >
           {results.length === 0 ? (
             <li className="px-4 py-3 text-sm text-text-dim">

--- a/site/src/pages/docs/index.astro
+++ b/site/src/pages/docs/index.astro
@@ -13,6 +13,7 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { getDocsNav } from '../../lib/nav';
 import { withBase } from '../../lib/url';
+import DocsSearchBar from '../../components/react/DocsSearchBar.tsx';
 
 const nav = await getDocsNav();
 const docsCount = nav.reduce((acc, group) => acc + group.items.length, 0);
@@ -24,6 +25,16 @@ const githubRepo = 'https://github.com/Chappygo-OS/Atomic-Spec';
   description="Atomic Spec documentation: installation, quick start, governance concepts, and contribution guides for the Atomic Traceability Model."
 >
   <section class="mx-auto max-w-6xl px-4 py-16 sm:px-6 lg:px-8">
+    {/* Docs-landing hero search — spans the full inner-container width
+        (max-w-6xl minus the section's horizontal padding), sits above the
+        page header, and uses the `hero` variant of DocsSearchBar for a
+        larger tap target + inviting placeholder. `client:load` because
+        search is the primary action on this page; hydrate immediately
+        rather than waiting for idle. */}
+    <div class="mb-10">
+      <DocsSearchBar variant="hero" client:load />
+    </div>
+
     <header class="mb-14 max-w-3xl">
       <p class="font-mono text-[11px] uppercase tracking-[0.22em] text-emerald-300">
         Documentation


### PR DESCRIPTION
## Summary

Adds a prominently-styled search bar to the `/docs` landing page, sitting above the "Documentation / Everything you need to install, run, and extend Atomic Spec." header and spanning the full inner-container width (`max-w-6xl` minus section padding).

## What changed

- `DocsSearchBar` gains an optional `variant?: 'sidebar' | 'hero'` prop. Default `sidebar` preserves current behavior for the two live callers (`DocsSidebar.astro`, `DocsSidebarMobile.tsx`).
- New `hero` variant: `min-h-[56px]`, `text-base sm:text-lg`, `rounded-xl`, `shadow-2xl` dropdown, longer inviting placeholder. Behavior + accessibility surface identical to the sidebar variant.
- `/docs/index.astro` renders `<DocsSearchBar variant="hero" client:load />` in a `<div class="mb-10">` above the existing `<header>`. `client:load` because search is the primary action on this page.

## Design decisions

- **Full container width**: not constrained to `max-w-3xl` (which the header sits inside for prose readability); the search input reads best when it spans the full grid width so the eye lands there first.
- **Design tokens over the older slate/emerald palette**: uses `bg-surface-1`, `border-border`, `text-text`, `focus:border-primary` — matching the v0.4 tokens the sidebar variant already ships with, rather than the older `slate-800`/`emerald-300` used by neighbouring category cards. Introduces a small visual dissonance with the older cards but points forward.
- **`min-h-[56px]`** on the hero input: comfortably above 44px HIG minimum, feels appropriate at hero scale without dominating.
- **Placeholder copy**: "Search the docs — nine directives, install, upgrade, verification…" — hints at what to try rather than just "Search docs...".

## Test plan

- [x] `npm run test` — 31/31 pass (scoring logic untouched)
- [x] `npm run build` — 13 pages, no MDX errors
- [ ] Live check that the hero input on `/docs` looks right at 375px / 768px / 1440px and doesn't overflow
- [ ] Verify the sidebar/mobile-drawer variants still render as before (they use the default variant)