### PR TITLE
chore: Google Search Console verification file

### DIFF
--- a/site/public/googlea81f0d8962b3a25e.html
+++ b/site/public/googlea81f0d8962b3a25e.html
@@ -1,0 +1,1 @@
+google-site-verification: googlea81f0d8962b3a25e.html


### PR DESCRIPTION
## Summary

Adds the Google Search Console HTML verification token so ownership of https://chappygo-os.github.io/Atomic-Spec/ can be verified.

## What changed

- New file: `site/public/googlea81f0d8962b3a25e.html`
- Content: the standard Google verification token line
- Astro serves the `site/public/` tree at the site's base path, so this file lands at `https://chappygo-os.github.io/Atomic-Spec/googlea81f0d8962b3a25e.html` — the exact URL Search Console expects.

## Why not `assets/`?

The file was originally dropped into the repo-root `/assets/` folder. That folder holds source branding images (banner, icon) but is not served — Astro's static-file directory is `site/public/`.

## Do not remove after verification

Google requires the file to remain in place indefinitely to keep verification active. Keep it in the repo permanently.

## Test plan

- [x] `npm run build` — file emitted at `site/dist/googlea81f0d8962b3a25e.html` with correct content
- [ ] After merge + Pages deploy: `curl -s https://chappygo-os.github.io/Atomic-Spec/googlea81f0d8962b3a25e.html` returns the token
- [ ] Click "Verify" in Google Search Console