### PR TITLE
site: LinkedIn badges (lazy) on homepage bottom

### DIFF
--- a/site/src/components/astro/Footer.astro
+++ b/site/src/components/astro/Footer.astro
@@ -3,15 +3,15 @@
  * Footer — site-wide footer.
  *
  * Brand line, three column links (Product / Resources / Community),
- * a small "Built by" maintainer strip, copyright, and license attribution
- * per the README's MIT licensing and upstream-fork acknowledgement.
+ * copyright, and license attribution per the README's MIT licensing and
+ * upstream-fork acknowledgement.
  *
  * GitHub URL repointed from the dead `custom-speckit` org to the canonical
- * `Chappygo-OS/Atomic-Spec`. Community-column LinkedIn link → Chappygo
- * company site; personal maintainer profiles live in the Built-by strip
- * below so the two ownership signals aren't conflated.
+ * `Chappygo-OS/Atomic-Spec`. Community-column entry links to Chappygo
+ * (the company entity) — personal maintainer profiles live in the
+ * homepage's `BuiltBy` section (LinkedIn badges, lazy-loaded), not here,
+ * so ownership signals aren't conflated.
  */
-import { Icon } from 'astro-icon/components';
 import { withBase } from '../../lib/url';
 
 interface FooterLink {
@@ -23,16 +23,6 @@ interface FooterLink {
 interface FooterColumn {
   title: string;
   links: FooterLink[];
-}
-
-interface Maintainer {
-  /** Two-letter monogram for the avatar tile. */
-  initials: string;
-  name: string;
-  /** Short role — kept ≤ 32 chars so chips don't wrap on mobile. */
-  role: string;
-  /** LinkedIn profile URL. Opens in a new tab. */
-  linkedin: string;
 }
 
 const docs = withBase('/docs');
@@ -85,27 +75,6 @@ const columns: FooterColumn[] = [
   },
 ];
 
-// Both maintainers get equal billing, each credited for the load-bearing
-// framework pillar they own. Mohammad designed the Nine Prime Directives —
-// the governance logic that separates Atomic Spec from spec-kit upstream.
-// Pablo designed the Assembly-Line mental model — the metaphor that carries
-// the framework's positioning ("phases → stations → gates"). Both credits
-// point at named concepts a reader can go verify on the homepage.
-const maintainers: Maintainer[] = [
-  {
-    initials: 'MK',
-    name: 'Mohammad Khoddami',
-    role: 'Maintainer · Prime Directives',
-    linkedin: 'https://www.linkedin.com/in/mohammadkhoddami/',
-  },
-  {
-    initials: 'PN',
-    name: 'Pablo Nastar',
-    role: 'Maintainer · Assembly Line',
-    linkedin: 'https://www.linkedin.com/in/pablo-nastar/',
-  },
-];
-
 const year = new Date().getFullYear();
 ---
 
@@ -150,59 +119,8 @@ const year = new Date().getFullYear();
       }
     </div>
 
-    {/* "Built by" strip — a small, honest maintainer surface. Sits between
-        the three-column link grid and the copyright row so it reads as
-        "who ships this" rather than a marketing surface. Two mini-chips
-        per maintainer: monogram avatar (iris tint, no photo file dependency),
-        name, role, and a LinkedIn icon-button as the tap target. Chips
-        stack vertically on mobile, sit side-by-side from sm+. */}
     <div
-      class="mt-12 border-t border-slate-900 pt-6"
-      aria-label="Maintainers"
-    >
-      <p class="mb-4 text-xs font-bold uppercase tracking-wider text-slate-400">
-        Built by
-      </p>
-      <ul class="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:gap-4">
-        {
-          maintainers.map((m) => (
-            <li>
-              <a
-                href={m.linkedin}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label={`${m.name} on LinkedIn`}
-                class="group inline-flex min-h-[44px] items-center gap-3 rounded-lg border border-slate-800 bg-slate-900/40 px-3 py-2 transition-colors hover:border-emerald-400/40 hover:bg-slate-900/70"
-              >
-                <span
-                  aria-hidden="true"
-                  class="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-emerald-400/20 bg-emerald-400/10 font-mono text-[11px] font-bold uppercase tracking-wider text-emerald-300"
-                >
-                  {m.initials}
-                </span>
-                <span class="flex min-w-0 flex-col">
-                  <span class="text-sm font-medium text-slate-200 transition-colors group-hover:text-white">
-                    {m.name}
-                  </span>
-                  <span class="text-[11px] uppercase tracking-wider text-slate-500 group-hover:text-slate-400">
-                    {m.role}
-                  </span>
-                </span>
-                <Icon
-                  name="lucide:linkedin"
-                  size={16}
-                  aria-hidden="true"
-                  class="ml-1 text-slate-500 transition-colors group-hover:text-emerald-300"
-                />
-              </a>
-            </li>
-          ))
-        }
-      </ul>
-    </div>
-
-    <div
-      class="mt-8 flex flex-col items-center justify-between gap-3 border-t border-slate-900 pt-6 text-xs text-slate-500 md:flex-row"
+      class="mt-12 flex flex-col items-center justify-between gap-3 border-t border-slate-900 pt-6 text-xs text-slate-500 md:flex-row"
     >
       <p>
         &copy; {year} Atomic Spec contributors. MIT-licensed. Forked from{' '}

--- a/site/src/components/react/BuiltBy.tsx
+++ b/site/src/components/react/BuiltBy.tsx
@@ -1,0 +1,146 @@
+/**
+ * BuiltBy — bottom-of-homepage maintainer section.
+ *
+ * Renders LinkedIn official profile badges for the two maintainers,
+ * lazy-loaded on two levels so nothing from `platform.linkedin.com`
+ * loads until the user actually reaches this section:
+ *
+ *   1. `client:visible` on the island (in index.astro) — Astro hydrates
+ *      this component only when its bounding box scrolls in. No React,
+ *      no useEffect, no script injection until the user gets here.
+ *   2. LinkedIn's badge script uses their standard fallback-inside-the-div
+ *      pattern — before the script loads (or if it never does, e.g.
+ *      adblocker / LinkedIn CDN down), our own placeholder content
+ *      stays visible. When the script fires, LinkedIn replaces the
+ *      contents of each `.LI-profile-badge` div with its own iframe.
+ *
+ * Zero third-party cost on landing. Zero blocked render. Fallback that
+ * never leaves the reader looking at a blank card.
+ *
+ * Trade-off (accepted deliberately): once LinkedIn's iframe renders,
+ * the badge design is LinkedIn's, not ours. The wrapper `<div>` keeps
+ * a subtle site-native frame around it (rounded, border, dark surface).
+ */
+import { useEffect } from 'react';
+
+interface Maintainer {
+  /** LinkedIn URL slug (the /in/{vanity} portion). */
+  vanity: string;
+  name: string;
+  /** Short role label — kept ≤ ~40 chars so the placeholder doesn't wrap. */
+  role: string;
+  /** Two-letter monogram used in the fallback avatar. */
+  initials: string;
+}
+
+const MAINTAINERS: Maintainer[] = [
+  {
+    vanity: 'mohammadkhoddami',
+    name: 'Mohammad Khoddami',
+    role: 'Maintainer · Prime Directives',
+    initials: 'MK',
+  },
+  {
+    vanity: 'pablo-nastar',
+    name: 'Pablo Nastar',
+    role: 'Maintainer · Assembly Line',
+    initials: 'PN',
+  },
+];
+
+const LINKEDIN_BADGE_SRC = 'https://platform.linkedin.com/badges/js/profile.js';
+
+/**
+ * Idempotently inject LinkedIn's badge script. Guards against duplicate
+ * injection if this component is unmounted+remounted for any reason.
+ */
+function injectLinkedInBadgeScript(): void {
+  if (typeof document === 'undefined') return;
+  if (document.querySelector(`script[src="${LINKEDIN_BADGE_SRC}"]`)) return;
+  const script = document.createElement('script');
+  script.src = LINKEDIN_BADGE_SRC;
+  script.async = true;
+  script.defer = true;
+  document.head.appendChild(script);
+}
+
+export default function BuiltBy() {
+  useEffect(() => {
+    // If this useEffect fires, the island has already been hydrated,
+    // which under `client:visible` means the user has scrolled here.
+    // Safe to load the script now.
+    injectLinkedInBadgeScript();
+  }, []);
+
+  return (
+    <section
+      id="built-by"
+      className="border-t border-slate-800/50 py-24"
+      aria-labelledby="built-by-heading"
+    >
+      <div className="container mx-auto px-4">
+        <div className="mb-12 text-center">
+          <p className="mb-3 font-mono text-[11px] uppercase tracking-[0.22em] text-emerald-300">
+            The humans
+          </p>
+          <h2
+            id="built-by-heading"
+            className="text-3xl font-bold text-white md:text-4xl"
+          >
+            Built by
+          </h2>
+          <p className="mx-auto mt-4 max-w-xl text-slate-400">
+            Two maintainers steward this fork. Each owns a load-bearing
+            pillar of the framework — the Nine Prime Directives and the
+            Assembly Line mental model.
+          </p>
+        </div>
+
+        <div className="mx-auto grid max-w-3xl gap-6 sm:grid-cols-2">
+          {MAINTAINERS.map((m) => (
+            <div
+              key={m.vanity}
+              className="badge-base LI-profile-badge relative min-h-[340px] overflow-hidden rounded-xl border border-slate-800 bg-slate-900/40"
+              data-locale="en_US"
+              data-size="medium"
+              data-theme="dark"
+              data-type="VERTICAL"
+              data-vanity={m.vanity}
+              data-version="v1"
+            >
+              {/* Fallback / placeholder content — visible while LinkedIn's
+                  script hasn't rendered (before scroll, during script
+                  download, or permanently if the script never loads).
+                  LinkedIn's script replaces the contents of the .LI-profile-badge
+                  div when it fires, so this whole block gets swapped
+                  out gracefully. If the script is blocked (adblocker,
+                  CSP, LinkedIn CDN down), this stays as the honest
+                  fallback state. */}
+              <div className="flex h-full flex-col items-center justify-center gap-3 p-8 text-center">
+                <div
+                  aria-hidden="true"
+                  className="mb-2 inline-flex h-16 w-16 items-center justify-center rounded-full border border-emerald-400/20 bg-emerald-400/10 font-mono text-lg font-bold uppercase tracking-wider text-emerald-300"
+                >
+                  {m.initials}
+                </div>
+                <p className="text-lg font-semibold text-white">{m.name}</p>
+                <p className="text-xs uppercase tracking-wider text-slate-500">
+                  {m.role}
+                </p>
+                <a
+                  className="badge-base__link LI-simple-link mt-2 inline-flex items-center gap-1 text-sm text-emerald-300 transition-colors hover:text-emerald-200 hover:underline"
+                  href={`https://www.linkedin.com/in/${m.vanity}?trk=profile-badge`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  View LinkedIn profile
+                  <span aria-hidden="true">→</span>
+                </a>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -29,6 +29,7 @@ import Agents from '../components/astro/Agents.astro';
 import HITL from '../components/react/HITL.tsx';
 import ContextPinning from '../components/react/ContextPinning.tsx';
 import Workflow from '../components/astro/Workflow.astro';
+import BuiltBy from '../components/react/BuiltBy.tsx';
 ---
 
 <BaseLayout
@@ -45,4 +46,5 @@ import Workflow from '../components/astro/Workflow.astro';
   <HITL client:visible />
   <ContextPinning client:visible />
   <Workflow />
+  <BuiltBy client:visible />
 </BaseLayout>


### PR DESCRIPTION
## Summary

Swaps the previous PR's hand-authored footer maintainer chips for **official LinkedIn profile badges**, moved from the footer to a new **bottom-of-homepage "Built by"** section. Lazy-loaded so nothing from `platform.linkedin.com` touches the network until the reader actually scrolls to the section.

## What changed

- New file: `site/src/components/react/BuiltBy.tsx` — React island rendering two LinkedIn `.LI-profile-badge` divs.
- Wired into `site/src/pages/index.astro` as the last section (`client:visible` hydration).
- Removed the "Built by" strip from `Footer.astro` (kept the Community-column `LinkedIn → Chappygo` swap — separate concern, separate slot).

## How the lazy load works

Two independent gates, both must be crossed before LinkedIn sees a request:

1. **`client:visible`** on the island → Astro's IntersectionObserver holds React hydration until the section scrolls in. If the user never scrolls that far, no React and no LinkedIn script.
2. **Placeholder-inside-badge fallback pattern** → each `.LI-profile-badge` div ships with a rich fallback (monogram avatar + name + role + LinkedIn link) as its child. LinkedIn's script replaces the child when it loads. If the script is blocked (adblocker / CSP / CDN down), the placeholder stays permanently — never a blank card.

## Trade-off (accepted deliberately)

Once LinkedIn renders, the card design is LinkedIn's iframe, not the site's design tokens. The wrapper `<div>` keeps a subtle site-native frame (rounded, border, dark surface) so it doesn't look completely alien. This was the explicit user preference over the hand-authored chips.

## Maintainer credits (unchanged from prior PR)

- **Mohammad Khoddami · Maintainer · Prime Directives**
- **Pablo Nastar · Maintainer · Assembly Line**

## Test plan

- [x] `npm run build` — 13 pages, no MDX errors
- [x] `npm run test` — 31/31 pass (search suite untouched)
- [ ] Live: verify Network panel shows no request to `platform.linkedin.com` on initial page load
- [ ] Live: scroll to bottom, confirm LinkedIn badges render + are clickable
- [ ] Live: with adblocker, confirm the placeholder card stays visible + LinkedIn link works